### PR TITLE
Show source reference in newsletter emails

### DIFF
--- a/app/views/newsletter_mailer/article_email.html.erb
+++ b/app/views/newsletter_mailer/article_email.html.erb
@@ -14,6 +14,15 @@
       .article-content {
         margin: 20px 0;
       }
+      .source-reference__quote {
+        border: 0 solid #ccc;
+        border-left-width: 0.3em;
+        margin: 0 0 0.75rem 0.3em;
+        padding-left: 0.6em;
+      }
+      .source-reference__links {
+        margin-top: 0.75rem;
+      }
       .footer {
         margin-top: 40px;
         padding-top: 20px;
@@ -40,6 +49,10 @@
     
     <% if @article.description.present? %>
       <p><%= @article.description %></p>
+    <% end %>
+
+    <% if @article.has_source? %>
+      <%= render "articles/source_reference", article: @article %>
     <% end %>
 
     <div class="article-content">
@@ -69,4 +82,3 @@
     </div>
   </body>
 </html>
-

--- a/app/views/newsletter_mailer/article_email.text.erb
+++ b/app/views/newsletter_mailer/article_email.text.erb
@@ -4,6 +4,17 @@
 <%= @article.description %>
 
 <% end %>
+<% if @article.has_source? %>
+参考:
+<% if @article.source_author.present? %>
+来源: <%= ActionView::Base.full_sanitizer.sanitize(@article.source_author.to_s) %>
+<% end %>
+<% if @article.source_content.present? %>
+<%= ActionView::Base.full_sanitizer.sanitize(@article.source_content.to_s) %>
+<% end %>
+原文: <%= @article.source_url %>
+
+<% end %>
 <% if @article.html? %>
 <%= ActionView::Base.full_sanitizer.sanitize(@article.html_content || "") %>
 <% else %>
@@ -17,4 +28,3 @@
 <% end %>
 
 不想再收到这些邮件？取消订阅: <%= @unsubscribe_url %>
-

--- a/test/fixtures/articles.yml
+++ b/test/fixtures/articles.yml
@@ -48,3 +48,16 @@ shared_article:
   html_content: "<p>Shared article content</p>"
   created_at: <%= 1.day.ago %>
   updated_at: <%= 1.day.ago %>
+
+source_article:
+  title: "Source Article"
+  slug: "source-article"
+  description: "This is a sourced article"
+  status: publish
+  content_type: html
+  html_content: "<p>Source article content</p>"
+  source_author: "Example Author"
+  source_content: "Example source quote."
+  source_url: "https://example.com/source"
+  created_at: <%= 2.days.ago %>
+  updated_at: <%= 2.days.ago %>

--- a/test/mailers/newsletter_mailer_test.rb
+++ b/test/mailers/newsletter_mailer_test.rb
@@ -145,6 +145,27 @@ class NewsletterMailerTest < ActionMailer::TestCase
     end
   end
 
+  test "article_email includes source reference content" do
+    article = articles(:source_article)
+    subscriber = subscribers(:confirmed_subscriber)
+    site_info = { title: "My Blog", url: "https://frontend.example.com" }
+
+    with_env("RAILS_API_URL" => "https://api.example.com") do
+      email = NewsletterMailer.article_email(article, subscriber, site_info)
+
+      text_body = email.text_part.body.decoded
+      html_body = email.html_part.body.decoded
+
+      assert_includes html_body, article.source_author
+      assert_includes html_body, article.source_content
+      assert_includes html_body, article.source_url
+
+      assert_includes text_body, article.source_author
+      assert_includes text_body, article.source_content
+      assert_includes text_body, article.source_url
+    end
+  end
+
   private
 
   def with_env(env)


### PR DESCRIPTION
Adds article source reference content to newsletter email HTML and text views. Includes minimal styling for the quote block and a mailer test with a new fixture.