### PR TITLE
Remove static frontend comment hooks

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1132,12 +1132,9 @@ h2 {
     color: var(--text-color) !important;
 }
 
-[data-theme="dark"] #comment-success-message {
+[data-theme="dark"] .comment-success-message {
     background-color: #2a2a2a !important;
     border-color: var(--border-color) !important;
-}
-
-[data-theme="dark"] #comment-success-message p {
     color: var(--text-color) !important;
 }
 

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -132,5 +132,4 @@ class SubscriptionsController < ApplicationController
   end
 
   private
-
 end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -2,16 +2,7 @@ class SubscriptionsController < ApplicationController
   include CacheableSettings
   include MathCaptchaVerification
   # Allow unauthenticated users to subscribe/confirm/unsubscribe from public pages
-  allow_unauthenticated_access only: [ :index, :create, :options, :confirm, :unsubscribe ]
-
-  # Skip CSRF protection for subscriptions from static pages
-  skip_forgery_protection only: [ :create, :options ]
-  before_action :set_cors_headers, only: [ :create, :options ]
-
-  # Handle CORS preflight requests
-  def options
-    head :ok
-  end
+  allow_unauthenticated_access only: [ :index, :create, :confirm, :unsubscribe ]
 
   def index
     @subscriber = Subscriber.new
@@ -142,11 +133,4 @@ class SubscriptionsController < ApplicationController
 
   private
 
-  def set_cors_headers
-    # Allow cross-origin requests from static pages
-    headers["Access-Control-Allow-Origin"] = "*"
-    headers["Access-Control-Allow-Methods"] = "POST, OPTIONS"
-    headers["Access-Control-Allow-Headers"] = "Content-Type, X-Requested-With, Accept"
-    headers["Access-Control-Max-Age"] = "86400" # 24 hours
-  end
 end

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,25 +1,25 @@
 <% parent_id = local_assigns[:parent_id] %>
 <% is_reply = parent_id.present? %>
 <% is_mobile = mobile_device? %>
-<div class="comment-form <%= 'reply-form' if is_reply %>" id="<%= is_reply ? "comment-form-#{parent_id}" : 'comment-form-container' %>" style="margin-top: <%= is_reply ? '0.5rem' : '1.5rem' %>; padding: 1rem; border: 1px solid #e0e0e0; border-radius: 6px; background: #fafafa;" <%= "data-controller=math-captcha data-math-captcha-max-value=10" unless is_mobile %>>
-  <% if (flash[:comment_submitted].present? || params[:comment_submitted].present?) && !is_reply %>
-    <div id="comment-success-message" style="text-align: center; border: 1px solid #333; padding: 0.75rem; border-radius: 4px; margin-bottom: 0.75rem; background: #fff;">
-      <p style="margin: 0; font-size: 0.875rem; color: #333;">Your comment will be reviewed before being published.</p>
-    </div>
-  <% end %>
-
-  <%
-    # Determine the form URL based on whether we have @page or @article
+<%
+  commentable =
     if defined?(@page) && @page.present?
-      form_url = comments_path(page_id: @page.slug)
+      @page
     elsif defined?(@article) && @article.present?
-      form_url = comments_path(article_id: @article.slug)
-    elsif defined?(@commentable)
-      form_url = @commentable.is_a?(Page) ? comments_path(page_id: @commentable.slug) : comments_path(article_id: @commentable.slug)
-    else
-      form_url = comments_path(article_id: '')
+      @article
+    elsif defined?(@commentable) && @commentable.present?
+      @commentable
     end
-  %>
+  show_success = !is_reply && flash[:comment_submitted].present?
+
+  form_url =
+    if commentable.present?
+      commentable.is_a?(Page) ? comments_path(page_id: commentable.slug) : comments_path(article_id: commentable.slug)
+    else
+      comments_path(article_id: "")
+    end
+%>
+<div class="comment-form <%= 'reply-form' if is_reply %>" id="<%= is_reply ? "comment-form-#{parent_id}" : 'comment-form-container' %>" style="margin-top: <%= is_reply ? '0.5rem' : '1.5rem' %>; padding: 1rem; border: 1px solid #e0e0e0; border-radius: 6px; background: #fafafa;" <%= "data-controller=math-captcha data-math-captcha-max-value=10" unless is_mobile %>>
   <%= form_with(model: comment, url: form_url, data: is_mobile ? {} : { action: "submit->math-captcha#ensureValid" }) do |f| %>
     <%= f.hidden_field :parent_id, value: parent_id if parent_id %>
     <% unless is_mobile %>
@@ -53,8 +53,13 @@
     </div>
     <% end %>
 
-    <div style="display: flex; gap: 0.5rem; align-items: center;">
+    <div style="display: flex; gap: 0.5rem; align-items: center; flex-wrap: wrap;">
       <%= f.submit is_reply ? "Reply" : "Submit", style: "padding: 0.5rem 1.25rem; background-color: #333; color: white; border: none; border-radius: 4px; cursor: pointer; font-size: 0.875rem;" %>
+      <% if show_success %>
+        <span class="comment-success-message" style="display: inline-flex; align-items: center; border: 1px solid #333; padding: 0.35rem 0.5rem; border-radius: 4px; background: #fff; font-size: 0.8rem; color: #333;">
+          Your comment will be reviewed before being published.
+        </span>
+      <% end %>
       <% if is_reply %>
         <button type="button" onclick="hideReplyForm(<%= parent_id %>)" style="padding: 0.5rem 1rem; background-color: #f0f0f0; color: #666; border: 1px solid #ddd; border-radius: 4px; cursor: pointer; font-size: 0.875rem;">Cancel</button>
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,8 +12,6 @@ Rails.application.routes.draw do
   resources :subscriptions, only: [ :index, :create ]
   get "/confirm", to: "subscriptions#confirm", as: :confirm_subscription
   get "/unsubscribe", to: "subscriptions#unsubscribe", as: :unsubscribe
-  # Handle CORS preflight requests for subscriptions (static pages fetch)
-  match "/subscriptions", to: "subscriptions#options", via: :options
 
   # Admin namespace - 统一所有后台管理功能
   namespace :admin do
@@ -113,9 +111,6 @@ Rails.application.routes.draw do
 
   # Public comment submission
   resources :comments, only: [ :create ]
-
-  # Handle CORS preflight requests for comments
-  match "/comments", to: "comments#options", via: :options
 
   # Static files public access
   get "/static/*filename", to: "static_files#show", as: :static_file, format: false

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -54,6 +54,9 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to article_path(article)
     follow_redirect!
     assert_response :success
-    assert_select "#comment-success-message", /Your comment will be reviewed/
+    # Success message is now inline in the comment form, not in flash notice
+    assert_select ".flash-notice", false
+    assert_select ".comment-form .comment-success-message", /Your comment will be reviewed/
   end
+
 end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -58,5 +58,4 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".flash-notice", false
     assert_select ".comment-form .comment-success-message", /Your comment will be reviewed/
   end
-
 end

--- a/test/controllers/subscriptions_controller_test.rb
+++ b/test/controllers/subscriptions_controller_test.rb
@@ -10,18 +10,6 @@ class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
     { captcha: { a:, b:, op:, answer: (answer || expected).to_s } }
   end
 
-  test "should respond to CORS preflight for subscriptions" do
-    options subscriptions_path, headers: {
-      "Origin" => "https://example.com",
-      "Access-Control-Request-Method" => "POST",
-      "Access-Control-Request-Headers" => "X-Requested-With, Accept"
-    }
-
-    assert_response :success
-    assert_equal "*", response.headers["Access-Control-Allow-Origin"]
-    assert_includes response.headers["Access-Control-Allow-Methods"], "POST"
-  end
-
   test "should create subscription" do
     assert_difference "Subscriber.count", 1 do
       post subscriptions_path, params: {


### PR DESCRIPTION
Remove static frontend CORS and redirect logic for comments and subscriptions. Simplify comment success rendering to rely on flash only, and clean up related routes/tests.