### PR TITLE
Include source references in Listmonk newsletters

### DIFF
--- a/app/models/listmonk.rb
+++ b/app/models/listmonk.rb
@@ -88,7 +88,7 @@ class Listmonk < ApplicationRecord
         type: "regular",
         content_type: "html",
         messenger: "email",
-        body: article.html? ? (article.html_content || "") : article.content.to_s,
+        body: campaign_body(article),
         template_id: template_id,
         send_later: false
       }.to_json
@@ -160,5 +160,19 @@ class Listmonk < ApplicationRecord
       )
       nil
     end
+  end
+
+  private
+
+  def campaign_body(article)
+    base_body = article.html? ? (article.html_content || "") : article.content.to_s
+    return base_body unless article.has_source?
+
+    reference_html = ApplicationController.renderer.render(
+      partial: "articles/source_reference",
+      locals: { article: article }
+    )
+
+    "#{reference_html}\n#{base_body}"
   end
 end

--- a/test/models/listmonk_test.rb
+++ b/test/models/listmonk_test.rb
@@ -1,0 +1,26 @@
+require "test_helper"
+
+class ListmonkTest < ActiveSupport::TestCase
+  test "campaign_body includes source reference before content when article has source" do
+    listmonk = Listmonk.new
+    article = articles(:source_article)
+
+    body = listmonk.send(:campaign_body, article)
+
+    assert_includes body, "Example Author"
+    assert_includes body, "Example source quote."
+    assert_includes body, "https://example.com/source"
+    assert_includes body, "<p>Source article content</p>"
+    assert body.index("Example source quote.") < body.index("Source article content")
+  end
+
+  test "campaign_body does not add reference when article has no source" do
+    listmonk = Listmonk.new
+    article = articles(:published_article)
+
+    body = listmonk.send(:campaign_body, article)
+
+    refute_includes body, "source-reference__quote"
+    assert_includes body, "<p>Published article content</p>"
+  end
+end


### PR DESCRIPTION
Adds source reference rendering to Listmonk campaign bodies when articles include citations. Includes a model test covering sourced and non-sourced articles.