### PR TITLE
Show commentable for reply comments

### DIFF
--- a/app/controllers/admin/comments_controller.rb
+++ b/app/controllers/admin/comments_controller.rb
@@ -2,7 +2,7 @@ class Admin::CommentsController < AdminController
   before_action :set_comment, only: [ :show, :edit, :update, :destroy, :approve, :reject ]
 
   def index
-    @comments = Comment.includes(:commentable)
+    @comments = Comment.includes(:commentable, :article, parent: :commentable)
 
     # Filter by status
     # Filter by status

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -33,6 +33,10 @@ class Comment < ApplicationRecord
 
   default_scope { order(published_at: :asc) }
 
+  def display_commentable
+    commentable || parent&.commentable || article
+  end
+
   # Trigger static generation when comment is created, updated, or status changes
 
   private

--- a/app/views/admin/comments/_form.html.erb
+++ b/app/views/admin/comments/_form.html.erb
@@ -2,13 +2,14 @@
   <div style="margin-bottom: 1rem;">
     <%= f.label :commentable, "Article/Page", style: "display: block; margin-bottom: 0.25rem; font-weight: bold;" %>
     <p style="margin: 0; padding: 0.5rem; background: #f5f5f5; border-radius: 4px;">
-      <% if @comment.commentable %>
-        <% if @comment.commentable.is_a?(Article) %>
-          Article: <%= @comment.commentable.title %>
-        <% elsif @comment.commentable.is_a?(Page) %>
-          Page: <%= @comment.commentable.title %>
+      <% display_commentable = @comment.display_commentable %>
+      <% if display_commentable %>
+        <% if display_commentable.is_a?(Article) %>
+          Article: <%= display_commentable.title %>
+        <% elsif display_commentable.is_a?(Page) %>
+          Page: <%= display_commentable.title %>
         <% else %>
-          <%= @comment.commentable.title %>
+          <%= display_commentable.title %>
         <% end %>
       <% else %>
         Unknown

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -92,13 +92,14 @@
                 </td>
                 <td class="col-title">
                   <% display_commentable = comment.display_commentable %>
+                  <% display_title = display_commentable&.title.presence || display_commentable&.try(:slug) %>
                   <% if display_commentable %>
                     <% if display_commentable.is_a?(Article) %>
-                      <%= link_to display_commentable.title.truncate(50), article_path(display_commentable), class: "title-link", target: "_blank" %>
+                      <%= link_to display_title.to_s.truncate(50), article_path(display_commentable), class: "title-link", target: "_blank" %>
                     <% elsif display_commentable.is_a?(Page) %>
-                      <%= link_to display_commentable.title.truncate(50), page_path(display_commentable), class: "title-link", target: "_blank" %>
+                      <%= link_to display_title.to_s.truncate(50), page_path(display_commentable), class: "title-link", target: "_blank" %>
                     <% else %>
-                      <%= display_commentable.title.truncate(50) %>
+                      <%= display_title.to_s.truncate(50) %>
                     <% end %>
                   <% else %>
                     <small class="text-muted">—</small>

--- a/app/views/admin/comments/index.html.erb
+++ b/app/views/admin/comments/index.html.erb
@@ -91,13 +91,14 @@
                   <small><%= comment.content.truncate(100) %></small>
                 </td>
                 <td class="col-title">
-                  <% if comment.commentable %>
-                    <% if comment.commentable.is_a?(Article) %>
-                      <%= link_to comment.commentable.title.truncate(50), article_path(comment.commentable), class: "title-link", target: "_blank" %>
-                    <% elsif comment.commentable.is_a?(Page) %>
-                      <%= link_to comment.commentable.title.truncate(50), page_path(comment.commentable), class: "title-link", target: "_blank" %>
+                  <% display_commentable = comment.display_commentable %>
+                  <% if display_commentable %>
+                    <% if display_commentable.is_a?(Article) %>
+                      <%= link_to display_commentable.title.truncate(50), article_path(display_commentable), class: "title-link", target: "_blank" %>
+                    <% elsif display_commentable.is_a?(Page) %>
+                      <%= link_to display_commentable.title.truncate(50), page_path(display_commentable), class: "title-link", target: "_blank" %>
                     <% else %>
-                      <%= comment.commentable.title.truncate(50) %>
+                      <%= display_commentable.title.truncate(50) %>
                     <% end %>
                   <% else %>
                     <small class="text-muted">—</small>

--- a/test/models/comment_test.rb
+++ b/test/models/comment_test.rb
@@ -99,6 +99,22 @@ class CommentTest < ActiveSupport::TestCase
     assert @comment.valid?
   end
 
+  test "display_commentable falls back to parent commentable" do
+    parent_comment = Comment.create!(
+      commentable: @article,
+      author_name: "Parent",
+      content: "Parent comment"
+    )
+
+    reply = Comment.new(
+      parent: parent_comment,
+      author_name: "Reply",
+      content: "Reply comment"
+    )
+
+    assert_equal parent_comment.commentable, reply.display_commentable
+  end
+
   test "local scope should return comments without platform" do
     local_comment = comments(:approved_comment)
     external_comment = comments(:mastodon_comment)

--- a/test/system/admin_comments_test.rb
+++ b/test/system/admin_comments_test.rb
@@ -1,0 +1,30 @@
+require "application_system_test_case"
+
+class AdminCommentsTest < ApplicationSystemTestCase
+  def setup
+    @user = users(:admin)
+  end
+
+  test "admin comments list shows slug when title is blank" do
+    article = Article.create!(
+      title: nil,
+      slug: "untitled-post",
+      description: "Untitled description",
+      status: :publish,
+      content_type: :html,
+      html_content: "<p>Body</p>"
+    )
+    comment = Comment.create!(
+      commentable: article,
+      author_name: "Alice",
+      content: "Comment for slug display"
+    )
+
+    sign_in(@user)
+    visit admin_comments_path
+
+    within find("tr", text: comment.content) do
+      assert_text "untitled-post"
+    end
+  end
+end


### PR DESCRIPTION
Adds a display_commentable helper and uses it in admin comments views to fall back to parent commentable. Includes a model test for the fallback.