### PR TITLE
Use setting URL for article and mailer links

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -46,6 +46,15 @@ module ApplicationHelper
     site_url
   end
 
+  def normalized_site_url
+    raw_url = site_settings[:url].to_s.strip
+    return "" if raw_url.blank?
+
+    site_url = raw_url.chomp("/")
+    site_url = "https://#{site_url}" unless site_url.match?(%r{^https?://})
+    site_url
+  end
+
   # Safely render HTML content by sanitizing dangerous tags while preserving common formatting
   def safe_html_content(html_content)
     return "".html_safe if html_content.blank?

--- a/app/mailers/newsletter_mailer.rb
+++ b/app/mailers/newsletter_mailer.rb
@@ -1,6 +1,14 @@
 require "uri"
 
 class NewsletterMailer < ApplicationMailer
+  def default_url_options
+    base = super || {}
+    options = active_storage_url_options(@site_url)
+    return base if options.blank?
+
+    base.merge(options)
+  end
+
   def article_email(article, subscriber, site_info)
     @article = article
     @subscriber = subscriber
@@ -124,10 +132,8 @@ class NewsletterMailer < ApplicationMailer
 
   def with_active_storage_url_options(site_url)
     previous = ActiveStorage::Current.url_options
-    if previous.blank?
-      options = active_storage_url_options(site_url)
-      ActiveStorage::Current.url_options = options if options.present?
-    end
+    options = active_storage_url_options(site_url)
+    ActiveStorage::Current.url_options = options if options.present?
     yield
   ensure
     ActiveStorage::Current.url_options = previous

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,7 @@
 class Setting < ApplicationRecord
   has_rich_text :footer
   before_save :parse_social_links_json
+  validates :url, presence: true, if: :setup_completed?
 
   # Virtual attribute for JSON textarea input
   attr_accessor :social_links_json

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -7,7 +7,7 @@
     <% if caption = blob.try(:caption) %>
       <%= caption %>
     <% else %>
-      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__name"><%= link_to blob.filename, rails_blob_url(blob, disposition: "attachment") %></span>
       <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
     <% end %>
   </figcaption>

--- a/app/views/articles/_article_list.html.erb
+++ b/app/views/articles/_article_list.html.erb
@@ -1,6 +1,8 @@
+<% site_url = normalized_site_url %>
 <div class="article-list timeline">
   <% articles.each do |article| %>
-    <article class="timeline-item" data-article-id="<%= article.id %>" data-controller="clickable-card" data-action="click->clickable-card#visit keydown.enter->clickable-card#visit keydown.space->clickable-card#visit" data-clickable-card-url-value="<%= article_path(article) %>" tabindex="0" role="link" aria-label="<%= article.title.presence || 'Open article' %>">
+    <% article_url = "#{site_url}#{article_path(article)}" %>
+    <article class="timeline-item" data-article-id="<%= article.id %>" data-controller="clickable-card" data-action="click->clickable-card#visit keydown.enter->clickable-card#visit keydown.space->clickable-card#visit" data-clickable-card-url-value="<%= article_url %>" tabindex="0" role="link" aria-label="<%= article.title.presence || 'Open article' %>">
       <div class="timeline-marker"></div>
       <div class="timeline-content">
         <div class="timeline-header">
@@ -21,7 +23,7 @@
           <div data-turbo-frame-loading-target="content">
             <% if article.title.present? %>
               <h2 class="post-title">
-                <%= link_to article.title, article_path(article), data: { turbo_frame: "article_#{article.id}" } %>
+                <%= link_to article.title, article_url, data: { turbo_frame: "article_#{article.id}" } %>
               </h2>
               <div class="loading-spinner" data-turbo-frame-loading-target="spinner" style="display: none; justify-content: left; align-items: left; padding: 20px;">
                 <i class="fas fa-spinner fa-spin" style="font-size: 24px; color: #c04000;"></i>
@@ -37,7 +39,7 @@
               <% end %>
             <% else %>
               <%= render 'articles/source_reference', article: article %>
-              <%= link_to article_path(article), class: "post-content-link", data: { turbo_frame: "article_#{article.id}" } do %>
+              <%= link_to article_url, class: "post-content-link", data: { turbo_frame: "article_#{article.id}" } do %>
                 <% if article.description.present? %>
                   <div class="post-description">
                     <%= article.description %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -5,15 +5,8 @@
 <% content_for :head do %>
   <% 
     # 构建文章完整URL
-    site_url = site_settings[:url].presence || request.base_url
-    site_url = site_url.chomp("/")
-    site_url = "https://#{site_url}" unless site_url.match?(%r{^https?://})
-    article_route_prefix = Rails.application.config.x.article_route_prefix 
-    if article_route_prefix.present?
-      article_full_url = "#{site_url}/#{article_route_prefix}/#{@article.slug}"
-    else
-      article_full_url = "#{site_url}/#{@article.slug}"
-    end
+    site_url = normalized_site_url
+    article_full_url = "#{site_url}#{article_path(@article)}"
     
     meta_title = @article.seo_meta_title
     meta_description = @article.seo_meta_description
@@ -59,15 +52,8 @@
 <article>
   <% 
     # 构建文章完整URL
-    site_url = site_settings[:url].presence || request.base_url
-    site_url = site_url.chomp("/")
-    site_url = "https://#{site_url}" unless site_url.match?(%r{^https?://})
-    article_route_prefix = Rails.application.config.x.article_route_prefix 
-    if article_route_prefix.present?
-      article_full_url = "#{site_url}/#{article_route_prefix}/#{@article.slug}"
-    else
-      article_full_url = "#{site_url}/#{@article.slug}"
-    end
+    site_url = normalized_site_url
+    article_full_url = "#{site_url}#{article_path(@article)}"
   %>
   <div class="article-header" style="display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: 0.25rem;">
     <h2 style="flex: 1; margin: 0;"><%= @article.title %></h2>

--- a/app/views/newsletter_mailer/article_email.html.erb
+++ b/app/views/newsletter_mailer/article_email.html.erb
@@ -64,8 +64,7 @@
     </div>
 
     <p>
-      <% article_url = "#{@site_info[:url]}/#{Rails.application.config.x.article_route_prefix || 'articles'}/#{@article.slug}" %>
-      <a href="<%= article_url %>">阅读全文</a>
+      <a href="<%= @article_url %>">阅读全文</a>
     </p>
 
     <% if @footer.present? %>

--- a/app/views/newsletter_mailer/article_email.text.erb
+++ b/app/views/newsletter_mailer/article_email.text.erb
@@ -21,7 +21,7 @@
 <%= ActionView::Base.full_sanitizer.sanitize(@article.content.to_s) %>
 <% end %>
 
-阅读全文: <%= @site_info[:url] %>/<%= Rails.application.config.x.article_route_prefix %>/<%= @article.slug %>
+阅读全文: <%= @article_url %>
 
 <% if @footer.present? %>
 <%= ActionView::Base.full_sanitizer.sanitize(@footer.to_s) %>

--- a/app/views/setup/show.html.erb
+++ b/app/views/setup/show.html.erb
@@ -69,7 +69,7 @@
 
         <div class="field">
           <%= setting_form.label :url, "Site URL" %>
-          <%= setting_form.text_field :url, placeholder: "https://yourblog.com", type: "url" %>
+          <%= setting_form.text_field :url, placeholder: "https://yourblog.com", type: "url", required: true %>
           <small>The full URL where your blog will be accessible</small>
         </div>
 

--- a/app/views/setup/show.html.erb
+++ b/app/views/setup/show.html.erb
@@ -11,10 +11,10 @@
         <strong>Please fix the following errors:</strong>
         <ul>
           <% @user.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
+            <li><%= sanitize(message) %></li>
           <% end %>
           <% @setting.errors.full_messages.each do |message| %>
-            <li><%= message %></li>
+            <li><%= sanitize(message) %></li>
           <% end %>
         </ul>
       </div>

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -28,6 +28,17 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "show uses setting url for article links" do
+    Setting.first.update!(url: "https://settings.example.com")
+    CacheableSettings.refresh_site_info
+
+    get article_path(@article.slug)
+    assert_response :success
+
+    expected_url = "https://settings.example.com#{article_path(@article)}"
+    assert_includes response.body, expected_url
+  end
+
   test "should sanitize script tags in html content" do
     article = create_published_article(html_content: "<p>Safe content</p><script>alert('xss')</script>")
 
@@ -135,5 +146,16 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
   test "should paginate articles" do
     get articles_path, params: { page: 1 }
     assert_response :success
+  end
+
+  test "index uses setting url for article links" do
+    Setting.first.update!(url: "https://settings.example.com")
+    CacheableSettings.refresh_site_info
+
+    get articles_path
+    assert_response :success
+
+    expected_url = "https://settings.example.com#{article_path(@article)}"
+    assert_includes response.body, "data-clickable-card-url-value=\"#{expected_url}\""
   end
 end

--- a/test/controllers/setup_controller_test.rb
+++ b/test/controllers/setup_controller_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class SetupControllerTest < ActionDispatch::IntegrationTest
+  test "setup requires site url" do
+    User.delete_all
+    Setting.delete_all
+
+    post setup_path, params: {
+      user: {
+        user_name: "admin",
+        password: "password123",
+        password_confirmation: "password123"
+      },
+      setting: {
+        title: "Test Site",
+        url: ""
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_match(/Url can't be blank/, response.body)
+  end
+end

--- a/test/fixtures/files/sample.txt
+++ b/test/fixtures/files/sample.txt
@@ -1,0 +1,1 @@
+Sample attachment contents.

--- a/test/views/active_storage/blobs/blob_test.rb
+++ b/test/views/active_storage/blobs/blob_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class ActiveStorage::Blobs::BlobTest < ActionView::TestCase
+  test "renders download link for non-previewable attachments" do
+    file = file_fixture("sample.txt")
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: file.open,
+      filename: "sample.txt",
+      content_type: "text/plain"
+    )
+
+    with_active_storage_url_options(host: "example.com") do
+      render partial: "active_storage/blobs/blob", locals: { blob: blob }
+
+      assert_select "a[href=?]", rails_blob_url(blob, disposition: "attachment"),
+                    text: blob.filename.to_s
+    end
+  end
+
+  private
+
+  def with_active_storage_url_options(options)
+    previous = ActiveStorage::Current.url_options
+    ActiveStorage::Current.url_options = options
+    yield
+  ensure
+    ActiveStorage::Current.url_options = previous
+  end
+end


### PR DESCRIPTION
Use the configured site URL for article links in pages and newsletters, and add tests for setup URL validation and attachment download links.