### PR TITLE
Fix untitled card link behavior

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -575,13 +575,17 @@ h2 {
 
 /* Article Content - Link Styles */
 
-.article-content a {
+.article-content a,
+.post-content a,
+.post-description a {
     color: #c04000 !important;
     text-decoration: underline !important;
     text-underline-offset: 2px;
 }
 
-.article-content a:hover {
+.article-content a:hover,
+.post-content a:hover,
+.post-description a:hover {
     color: #a03000 !important;
     text-decoration-thickness: 2px;
 }
@@ -1003,11 +1007,15 @@ h2 {
 }
 
 
-[data-theme="dark"] .article-content a {
+[data-theme="dark"] .article-content a,
+[data-theme="dark"] .post-content a,
+[data-theme="dark"] .post-description a {
     color: var(--accent-color) !important;
 }
 
-[data-theme="dark"] .article-content a:hover {
+[data-theme="dark"] .article-content a:hover,
+[data-theme="dark"] .post-content a:hover,
+[data-theme="dark"] .post-description a:hover {
     color: #ff8c5a !important;
 }
 

--- a/app/views/articles/_article_list.html.erb
+++ b/app/views/articles/_article_list.html.erb
@@ -39,16 +39,14 @@
               <% end %>
             <% else %>
               <%= render 'articles/source_reference', article: article %>
-              <%= link_to article_url, class: "post-content-link", data: { turbo_frame: "article_#{article.id}" } do %>
-                <% if article.description.present? %>
-                  <div class="post-description">
-                    <%= article.description %>
-                  </div>
-                <% else %>
-                  <div class="post-content">
-                    <%= article.html? ? safe_html_content(article.rendered_content) : article.rendered_content %>
-                  </div>
-                <% end %>
+              <% if article.description.present? %>
+                <div class="post-description">
+                  <%= article.description %>
+                </div>
+              <% else %>
+                <div class="post-content">
+                  <%= article.html? ? safe_html_content(article.rendered_content) : article.rendered_content %>
+                </div>
               <% end %>
             <% end %>
           </div>

--- a/test/controllers/articles_controller_test.rb
+++ b/test/controllers/articles_controller_test.rb
@@ -158,4 +158,20 @@ class ArticlesControllerTest < ActionDispatch::IntegrationTest
     expected_url = "https://settings.example.com#{article_path(@article)}"
     assert_includes response.body, "data-clickable-card-url-value=\"#{expected_url}\""
   end
+
+  test "index renders untitled article without wrapping content link" do
+    article = create_published_article(
+      title: nil,
+      description: nil,
+      slug: "untitled-article",
+      html_content: "<p>Text <a href=\"https://example.com\">report</a></p>"
+    )
+
+    get articles_path
+    assert_response :success
+
+    assert_select "article[data-article-id='#{article.id}'][data-controller~='clickable-card']", 1
+    assert_select "article[data-article-id='#{article.id}'] a.post-content-link", 0
+    assert_select "article[data-article-id='#{article.id}'] a[href='https://example.com']", 1
+  end
 end

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -54,6 +54,26 @@ class ArticlesTest < ApplicationSystemTestCase
     assert_text "Fallback content should appear"
   end
 
+  test "inline link inside untitled card follows its target" do
+    linked_article = create_published_article(title: "Linked Article", content: "<p>Linked content</p>")
+    link_href = article_path(linked_article)
+    untitled_article = create_published_article(
+      title: nil,
+      description: "",
+      slug: "untitled-article",
+      content: %(<p>Text <a href="#{link_href}">report</a></p>)
+    )
+
+    visit root_path
+
+    within "article[data-article-id='#{untitled_article.id}']" do
+      click_link "report"
+    end
+
+    assert_current_path link_href, ignore_query: true
+    assert_text linked_article.title
+  end
+
   test "space key works on nested interactive controls inside a clickable card" do
     skip "This test requires JavaScript support (Selenium)" unless self.class.use_selenium?
 


### PR DESCRIPTION
Removes the wrapper link for untitled cards so inline links work. Aligns card content link styles with article content styling. Adds controller and system tests for untitled card links.