### PR TITLE
Add source reference blocks to markdown exports

### DIFF
--- a/app/models/markdown_export.rb
+++ b/app/models/markdown_export.rb
@@ -47,6 +47,8 @@ class MarkdownExport
     Article.order(:id).includes(:tags).find_each do |article|
       html = html_for_article(article)
       markdown = ReverseMarkdown.convert(html, unknown_tags: :bypass, github_flavored: true, force_encoding: true).to_s
+      reference = reference_markdown_for(article)
+      body = [reference, markdown].reject(&:blank?).join("\n\n")
 
       front_matter = {
         "type" => "article",
@@ -65,7 +67,7 @@ class MarkdownExport
         dir: articles_dir,
         basename: safe_basename(article.slug.presence || "article_#{article.id}"),
         front_matter: front_matter,
-        body: markdown
+        body: body
       )
     end
 
@@ -129,6 +131,51 @@ class MarkdownExport
       end
 
     process_html_content(html, record_id: page.id, record_type: "page")
+  end
+
+  def reference_markdown_for(article)
+    return "" unless article.has_source?
+
+    author = sanitize_source_text(article.source_author)
+    content = sanitize_source_text(article.source_content, preserve_line_breaks: true)
+    url = sanitize_source_url(article.source_url)
+
+    return "" if author.blank? && content.blank? && url.blank?
+
+    lines = ["Reference:"]
+    lines << "Source: #{author}" if author.present?
+
+    quote_lines = []
+    if content.present?
+      quote_lines.concat(content.split(/\r?\n/))
+    end
+    if url.present?
+      quote_lines << "" if content.present?
+      quote_lines << "Original: #{url}"
+    end
+
+    if quote_lines.any?
+      lines << ""
+      lines.concat(quote_lines.map { |line| line.present? ? "> #{line}" : ">" })
+    end
+
+    lines.join("\n").strip
+  end
+
+  def sanitize_source_text(text, preserve_line_breaks: false)
+    text = text.to_s
+    if preserve_line_breaks
+      text = text.gsub(/<\s*br\s*\/?>/i, "\n")
+      text = text.gsub(/<\/\s*p\s*>/i, "\n")
+      text = text.gsub(/<\s*p[^>]*>/i, "")
+    end
+
+    sanitized = ActionView::Base.full_sanitizer.sanitize(text)
+    sanitized.gsub(/\r\n?/, "\n").strip
+  end
+
+  def sanitize_source_url(url)
+    sanitize_source_text(url).split(/\r?\n/).first.to_s.strip
   end
 
   def write_markdown_file(dir:, basename:, front_matter:, body:)

--- a/app/models/markdown_export.rb
+++ b/app/models/markdown_export.rb
@@ -48,7 +48,7 @@ class MarkdownExport
       html = html_for_article(article)
       markdown = ReverseMarkdown.convert(html, unknown_tags: :bypass, github_flavored: true, force_encoding: true).to_s
       reference = reference_markdown_for(article)
-      body = [reference, markdown].reject(&:blank?).join("\n\n")
+      body = [ reference, markdown ].reject(&:blank?).join("\n\n")
 
       front_matter = {
         "type" => "article",
@@ -142,7 +142,7 @@ class MarkdownExport
 
     return "" if author.blank? && content.blank? && url.blank?
 
-    lines = ["Reference:"]
+    lines = [ "Reference:" ]
     lines << "Source: #{author}" if author.present?
 
     quote_lines = []

--- a/test/models/markdown_export_test.rb
+++ b/test/models/markdown_export_test.rb
@@ -35,6 +35,99 @@ class MarkdownExportTest < ActiveSupport::TestCase
     File.delete(exporter.zip_path) if exporter&.zip_path.present? && File.exist?(exporter.zip_path)
   end
 
+  test "includes article source reference above content" do
+    exporter = MarkdownExport.new
+
+    assert exporter.generate, exporter.error_message
+    assert exporter.zip_path.present?
+    assert File.exist?(exporter.zip_path), "expected zip to exist at #{exporter.zip_path}"
+
+    Zip::File.open(exporter.zip_path) do |zip|
+      article_entry = zip.find_entry("articles/source-article.md")
+      assert article_entry, "expected articles/source-article.md to exist in zip"
+
+      article_content = article_entry.get_input_stream.read
+      assert_includes article_content, "Reference:"
+      assert_includes article_content, "Source: Example Author"
+      assert_includes article_content, "Example source quote."
+      assert_includes article_content, "Original: https://example.com/source"
+
+      reference_index = article_content.index("Reference:")
+      content_index = article_content.index("Source article content")
+      assert reference_index, "expected reference section to be present"
+      assert content_index, "expected article content to be present"
+      assert reference_index < content_index, "expected reference section to appear before article content"
+    end
+  ensure
+    File.delete(exporter.zip_path) if exporter&.zip_path.present? && File.exist?(exporter.zip_path)
+  end
+
+  test "sanitizes source reference content and url formatting" do
+    article = Article.create!(
+      title: "Source Formatting Article",
+      slug: "source-formatting-article",
+      description: "This is a source formatting article",
+      status: :publish,
+      content_type: :html,
+      html_content: "<p>Source formatting content</p>",
+      source_author: "<b>Example Author</b>",
+      source_content: "<p>Line one</p><p>Line two<br>Line three</p>",
+      source_url: "https://example.com/source\nextra"
+    )
+
+    exporter = MarkdownExport.new
+
+    assert exporter.generate, exporter.error_message
+    assert exporter.zip_path.present?
+    assert File.exist?(exporter.zip_path), "expected zip to exist at #{exporter.zip_path}"
+
+    Zip::File.open(exporter.zip_path) do |zip|
+      article_entry = zip.find_entry("articles/source-formatting-article.md")
+      assert article_entry, "expected articles/source-formatting-article.md to exist in zip"
+
+      article_content = article_entry.get_input_stream.read
+      assert_includes article_content, "Source: Example Author"
+      assert_includes article_content, "> Line one"
+      assert_includes article_content, "> Line two"
+      assert_includes article_content, "> Line three"
+      assert_includes article_content, "Original: https://example.com/source"
+      refute_includes article_content, "extra"
+    end
+  ensure
+    File.delete(exporter.zip_path) if exporter&.zip_path.present? && File.exist?(exporter.zip_path)
+    article&.destroy
+  end
+
+  test "skips reference section when source data sanitizes to blank" do
+    article = Article.create!(
+      title: "Blank Source Article",
+      slug: "blank-source-article",
+      description: "This is a blank source article",
+      status: :publish,
+      content_type: :html,
+      html_content: "<p>Blank source content</p>",
+      source_url: "<br>"
+    )
+
+    exporter = MarkdownExport.new
+
+    assert exporter.generate, exporter.error_message
+    assert exporter.zip_path.present?
+    assert File.exist?(exporter.zip_path), "expected zip to exist at #{exporter.zip_path}"
+
+    Zip::File.open(exporter.zip_path) do |zip|
+      article_entry = zip.find_entry("articles/blank-source-article.md")
+      assert article_entry, "expected articles/blank-source-article.md to exist in zip"
+
+      article_content = article_entry.get_input_stream.read
+      refute_includes article_content, "Reference:"
+      assert_includes article_content, "Blank source content"
+    end
+  ensure
+    File.delete(exporter.zip_path) if exporter&.zip_path.present? && File.exist?(exporter.zip_path)
+    article&.destroy
+  end
+
   test "uses UTF-8 filenames and markdown image syntax" do
     article = Article.create!(
       title: "中文标题",


### PR DESCRIPTION
Adds a reference block to markdown exports when source data is present and sanitizes source content and URLs. Includes tests for reference rendering, sanitization, and blank-source handling.