### PR TITLE
Add controller tests and admin redirect fix

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -17,7 +17,7 @@ class UsersController < ApplicationController
   def update
     @user = Current.user
     if @user.update(user_params)
-      redirect_to admin_posts_path, alert: "Account was successfully updated."
+      redirect_to admin_articles_path, alert: "Account was successfully updated."
     else
       render :edit, status: :unprocessable_entity
     end

--- a/test/controllers/admin/activities_controller_test.rb
+++ b/test/controllers/admin/activities_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Admin::ActivitiesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+  end
+
+  test "index lists recent activity logs" do
+    ActivityLog.create!(
+      action: "created",
+      target: "article",
+      level: :info,
+      description: "Created article from test"
+    )
+
+    get admin_activities_path
+    assert_response :success
+    assert_includes response.body, "Created article from test"
+  end
+end

--- a/test/controllers/admin/base_controller_test.rb
+++ b/test/controllers/admin/base_controller_test.rb
@@ -1,0 +1,66 @@
+require "test_helper"
+
+class Admin::DummyBaseController < Admin::BaseController
+  allow_unauthenticated_access
+
+  def index
+    fetch_articles(Article.all)
+    render plain: "ok"
+  end
+
+  private
+
+  def model_class
+    Article
+  end
+
+  def redirect_path_after_batch
+    "/admin/articles"
+  end
+end
+
+class Admin::BaseControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+  end
+
+  test "batch actions and fetch_articles in base controller" do
+    with_routing do |set|
+      set.draw do
+        namespace :admin do
+          get "dummy_base" => "dummy_base#index"
+          post "dummy_base/batch_destroy" => "dummy_base#batch_destroy"
+          post "dummy_base/batch_publish" => "dummy_base#batch_publish"
+          post "dummy_base/batch_unpublish" => "dummy_base#batch_unpublish"
+        end
+      end
+
+      get "/admin/dummy_base", params: { status: "draft" }
+      assert_response :success
+
+      draft_article = create_published_article(
+        status: :draft,
+        title: "Batch Draft",
+        slug: "batch-draft-#{Time.current.to_i}"
+      )
+
+      post "/admin/dummy_base/batch_publish", params: { ids: [ draft_article.slug ] }
+      assert_redirected_to "/admin/articles"
+      assert draft_article.reload.publish?
+
+      post "/admin/dummy_base/batch_unpublish", params: { ids: [ draft_article.slug ] }
+      assert_redirected_to "/admin/articles"
+      assert draft_article.reload.draft?
+
+      delete_article = create_published_article(
+        title: "Batch Delete",
+        slug: "batch-delete-#{Time.current.to_i}-#{rand(1000)}"
+      )
+
+      assert_difference "Article.count", -1 do
+        post "/admin/dummy_base/batch_destroy", params: { ids: [ delete_article.slug ] }
+      end
+    end
+  end
+end

--- a/test/controllers/admin/comments_controller_test.rb
+++ b/test/controllers/admin/comments_controller_test.rb
@@ -1,0 +1,59 @@
+require "test_helper"
+
+class Admin::CommentsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    @pending_comment = comments(:pending_comment)
+    @approved_comment = comments(:approved_comment)
+    sign_in(@user)
+  end
+
+  test "admin comment workflows" do
+    get admin_comments_path
+    assert_response :success
+
+    get admin_comments_path, params: { status: "approved" }
+    assert_response :success
+
+    get admin_comment_path(@pending_comment)
+    assert_response :not_acceptable
+
+    get edit_admin_comment_path(@pending_comment)
+    assert_response :success
+
+    patch admin_comment_path(@pending_comment), params: { comment: { content: "Updated content" } }
+    assert_redirected_to admin_comments_path
+    assert_equal "Updated content", @pending_comment.reload.content
+
+    patch admin_comment_path(@pending_comment), params: { comment: { author_name: "" } }
+    assert_response :unprocessable_entity
+
+    patch approve_admin_comment_path(@pending_comment)
+    assert_redirected_to admin_comments_path
+    assert @pending_comment.reload.approved?
+
+    patch reject_admin_comment_path(@approved_comment)
+    assert_redirected_to admin_comments_path
+    assert @approved_comment.reload.rejected?
+
+    batch_comment = Comment.create!(
+      commentable: articles(:published_article),
+      author_name: "Batch User",
+      content: "Batch content",
+      status: :pending
+    )
+
+    post batch_approve_admin_comments_path, params: { ids: [ batch_comment.id ] }
+    assert_redirected_to admin_comments_path
+    assert batch_comment.reload.approved?
+
+    post batch_reject_admin_comments_path, params: { ids: [ batch_comment.id ] }
+    assert_redirected_to admin_comments_path
+    assert batch_comment.reload.rejected?
+
+    assert_difference "Comment.count", -1 do
+      post batch_destroy_admin_comments_path, params: { ids: [ batch_comment.id ] }
+    end
+
+  end
+end

--- a/test/controllers/admin/comments_controller_test.rb
+++ b/test/controllers/admin/comments_controller_test.rb
@@ -54,6 +54,5 @@ class Admin::CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_difference "Comment.count", -1 do
       post batch_destroy_admin_comments_path, params: { ids: [ batch_comment.id ] }
     end
-
   end
 end

--- a/test/controllers/admin/crossposts_controller_test.rb
+++ b/test/controllers/admin/crossposts_controller_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class Admin::CrosspostsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+  end
+
+  test "index update and verify flows" do
+    get admin_crossposts_path
+    assert_response :success
+
+    patch admin_crosspost_path("mastodon"), params: {
+      crosspost: {
+        platform: "mastodon",
+        enabled: "0",
+        server_url: "https://mastodon.example"
+      }
+    }
+    assert_redirected_to admin_crossposts_path
+
+    patch admin_crosspost_path("mastodon"), params: {
+      crosspost: {
+        platform: "mastodon",
+        enabled: "1",
+        server_url: "https://mastodon.example"
+      }
+    }
+    assert_redirected_to admin_crossposts_path
+
+    with_stubbed_verify(MastodonService, { success: true }) do
+      post verify_admin_crosspost_path("mastodon"), params: {
+        crosspost: { platform: "mastodon" }
+      }, as: :json
+      assert_response :success
+      assert_equal "success", JSON.parse(response.body)["status"]
+    end
+
+    post verify_admin_crosspost_path("mastodon"), params: {
+      crosspost: { platform: "twitter" }
+    }, as: :json
+    assert_response :success
+    assert_equal "error", JSON.parse(response.body)["status"]
+
+    with_stubbed_verify(TwitterService, { success: false, error: "bad" }) do
+      post verify_admin_crosspost_path("twitter"), params: {
+        crosspost: { platform: "twitter" }
+      }, as: :json
+      assert_response :success
+      assert_equal "error", JSON.parse(response.body)["status"]
+    end
+
+    with_stubbed_verify(BlueskyService, { success: true }) do
+      post verify_admin_crosspost_path("bluesky"), params: {
+        crosspost: { platform: "bluesky" }
+      }, as: :json
+      assert_response :success
+      assert_equal "success", JSON.parse(response.body)["status"]
+    end
+
+    post verify_admin_crosspost_path("unknown"), params: {
+      crosspost: { platform: "unknown" }
+    }, as: :json
+    assert_response :success
+    assert_equal "error", JSON.parse(response.body)["status"]
+  end
+
+  private
+
+  def with_stubbed_verify(service_class, result)
+    original = service_class.instance_method(:verify)
+    service_class.define_method(:verify) { |_params| result }
+    yield
+  ensure
+    service_class.define_method(:verify, original)
+  end
+end

--- a/test/controllers/admin/git_integrations_controller_test.rb
+++ b/test/controllers/admin/git_integrations_controller_test.rb
@@ -57,7 +57,7 @@ class Admin::GitIntegrationsControllerTest < ActionDispatch::IntegrationTest
     assert_equal "Server URL is not allowed (loopback/link-local/multicast/unspecified)",
                  controller.send(:outbound_ip_disallowed_reason, IPAddr.new("127.0.0.1"))
     resolved = controller.send(:resolved_ips_for_host, "8.8.8.8")
-    assert_equal [IPAddr.new("8.8.8.8")], resolved
+    assert_equal [ IPAddr.new("8.8.8.8") ], resolved
   end
 
   test "test_connection covers all providers" do
@@ -129,7 +129,7 @@ class Admin::GitIntegrationsControllerTest < ActionDispatch::IntegrationTest
   def with_stubbed_resolved_ips
     original = Admin::GitIntegrationsController.instance_method(:resolved_ips_for_host)
     original_reason = Admin::GitIntegrationsController.instance_method(:outbound_ip_disallowed_reason)
-    Admin::GitIntegrationsController.define_method(:resolved_ips_for_host) { |_host| [IPAddr.new("8.8.8.8")] }
+    Admin::GitIntegrationsController.define_method(:resolved_ips_for_host) { |_host| [ IPAddr.new("8.8.8.8") ] }
     Admin::GitIntegrationsController.define_method(:outbound_ip_disallowed_reason) { |_ip| nil }
     yield
   ensure

--- a/test/controllers/admin/git_integrations_controller_test.rb
+++ b/test/controllers/admin/git_integrations_controller_test.rb
@@ -1,0 +1,139 @@
+require "test_helper"
+require "ipaddr"
+
+class Admin::GitIntegrationsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+  end
+
+  test "index update verify and helpers" do
+    get admin_git_integrations_path
+    assert_response :success
+
+    patch admin_git_integration_path("unknown"), params: {
+      git_integration: { enabled: "1" }
+    }
+    assert_response :not_found
+
+    patch admin_git_integration_path("github"), params: {
+      git_integration: {
+        enabled: "0",
+        access_token: "",
+        server_url: ""
+      }
+    }
+    assert_redirected_to admin_git_integrations_path
+
+    patch admin_git_integration_path("github"), params: {
+      git_integration: {
+        enabled: "1",
+        access_token: ""
+      }
+    }
+    assert_redirected_to admin_git_integrations_path
+
+    post verify_admin_git_integration_path("github"), params: {
+      git_integration: { access_token: "" }
+    }, as: :json
+    assert_response :success
+    assert_equal "error", JSON.parse(response.body)["status"]
+
+    with_stubbed_test_connection(success: true, message: "ok") do
+      post verify_admin_git_integration_path("github"), params: {
+        git_integration: { access_token: "token" }
+      }, as: :json
+      assert_response :success
+      assert_equal "success", JSON.parse(response.body)["status"]
+    end
+
+    post verify_admin_git_integration_path("unknown"), params: {
+      git_integration: { access_token: "token" }
+    }, as: :json
+    assert_response :not_found
+
+    controller = Admin::GitIntegrationsController.new
+    assert_raises(RuntimeError) { controller.send(:validate_outbound_base_url!, "http://localhost") }
+    assert_equal "Server URL is not allowed (loopback/link-local/multicast/unspecified)",
+                 controller.send(:outbound_ip_disallowed_reason, IPAddr.new("127.0.0.1"))
+    resolved = controller.send(:resolved_ips_for_host, "8.8.8.8")
+    assert_equal [IPAddr.new("8.8.8.8")], resolved
+  end
+
+  test "test_connection covers all providers" do
+    controller = Admin::GitIntegrationsController.new
+    response_body = {
+      login: "octo",
+      username: "octo",
+      display_name: "Octo User"
+    }.to_json
+
+    with_stubbed_resolved_ips do
+      with_stubbed_http(response_body) do
+        github = GitIntegration.new(provider: "github", name: "GitHub", access_token: "token")
+        gitlab = GitIntegration.new(provider: "gitlab", name: "GitLab", access_token: "token")
+        gitea = GitIntegration.new(provider: "gitea", name: "Gitea", access_token: "token", server_url: "https://gitea.example.com")
+        codeberg = GitIntegration.new(provider: "codeberg", name: "Codeberg", access_token: "token")
+        bitbucket = GitIntegration.new(provider: "bitbucket", name: "Bitbucket", access_token: "token", username: "bbuser")
+
+        results = {
+          github: controller.send(:test_connection, github),
+          gitlab: controller.send(:test_connection, gitlab),
+          gitea: controller.send(:test_connection, gitea),
+          codeberg: controller.send(:test_connection, codeberg),
+          bitbucket: controller.send(:test_connection, bitbucket)
+        }
+
+        results.each do |name, result|
+          assert result[:success], "#{name} failed: #{result.inspect}"
+        end
+      end
+    end
+  end
+
+  private
+
+  def with_stubbed_test_connection(result)
+    original = Admin::GitIntegrationsController.instance_method(:test_connection)
+    Admin::GitIntegrationsController.define_method(:test_connection) { |_integration| result }
+    yield
+  ensure
+    Admin::GitIntegrationsController.define_method(:test_connection, original)
+  end
+
+  FakeHttp = Struct.new(:response) do
+    def request(_request)
+      response
+    end
+  end
+
+  class FakeSuccess < Net::HTTPSuccess
+    def initialize(body)
+      super("1.1", "200", "OK")
+      @read = true
+      @body = body
+    end
+  end
+
+  def with_stubbed_http(body)
+    original_start = Net::HTTP.method(:start)
+    Net::HTTP.define_singleton_method(:start) do |_host, _port, **_opts, &block|
+      http = FakeHttp.new(FakeSuccess.new(body))
+      block ? block.call(http) : http
+    end
+    yield
+  ensure
+    Net::HTTP.define_singleton_method(:start, original_start)
+  end
+
+  def with_stubbed_resolved_ips
+    original = Admin::GitIntegrationsController.instance_method(:resolved_ips_for_host)
+    original_reason = Admin::GitIntegrationsController.instance_method(:outbound_ip_disallowed_reason)
+    Admin::GitIntegrationsController.define_method(:resolved_ips_for_host) { |_host| [IPAddr.new("8.8.8.8")] }
+    Admin::GitIntegrationsController.define_method(:outbound_ip_disallowed_reason) { |_ip| nil }
+    yield
+  ensure
+    Admin::GitIntegrationsController.define_method(:resolved_ips_for_host, original)
+    Admin::GitIntegrationsController.define_method(:outbound_ip_disallowed_reason, original_reason)
+  end
+end

--- a/test/controllers/admin/newsletter_controller_test.rb
+++ b/test/controllers/admin/newsletter_controller_test.rb
@@ -64,4 +64,129 @@ class Admin::NewsletterControllerTest < ActionDispatch::IntegrationTest
     assert_select "select#list-select"
     assert_select "select#template-select"
   end
+
+  test "verify listmonk responses and update listmonk settings" do
+    get admin_newsletter_path
+    assert_response :success
+
+    post verify_admin_newsletter_path, params: { username: "", api_key: "", url: "" }, as: :json
+    assert_response :unprocessable_entity
+    assert_equal false, JSON.parse(response.body)["success"]
+
+    ActivityLog.create!(
+      action: "failed",
+      target: "newsletter",
+      level: :error,
+      description: "Listmonk fetch failed"
+    )
+
+    with_stubbed_listmonk(configured: true, lists: [], templates: []) do
+      post verify_admin_newsletter_path, params: {
+        username: "user",
+        api_key: "key",
+        url: "https://listmonk.example"
+      }, as: :json
+      assert_response :unprocessable_entity
+      assert_equal false, JSON.parse(response.body)["success"]
+    end
+
+    with_stubbed_listmonk(configured: true, lists: [ { "id" => 1 } ], templates: [ { "id" => 2 } ]) do
+      post verify_admin_newsletter_path, params: {
+        username: "user",
+        api_key: "key",
+        url: "https://listmonk.example",
+        list_id: 1,
+        template_id: 2
+      }, as: :json
+      assert_response :success
+      assert_equal true, JSON.parse(response.body)["success"]
+    end
+
+    patch admin_newsletter_path, params: {
+      listmonk: {
+        enabled: "1",
+        url: "https://listmonk.example",
+        username: "user",
+        api_key: "key",
+        list_id: 1,
+        template_id: 2
+      }
+    }
+    assert_redirected_to admin_newsletter_path
+  end
+
+  test "verify smtp handles validation and authentication errors" do
+    post verify_admin_newsletter_path, params: { smtp_address: "", smtp_user_name: "" }, as: :json
+    assert_response :unprocessable_entity
+    assert_equal false, JSON.parse(response.body)["success"]
+
+    smtp_params = {
+      smtp_address: "smtp.example.com",
+      smtp_port: "587",
+      smtp_user_name: "user",
+      smtp_password: "secret",
+      smtp_domain: "example.com",
+      smtp_authentication: "plain",
+      smtp_enable_starttls: "1",
+      from_email: "noreply@example.com"
+    }
+
+    with_stubbed_smtp(behavior: :success) do
+      post verify_admin_newsletter_path, params: smtp_params, as: :json
+      assert_response :success
+      assert_equal true, JSON.parse(response.body)["success"]
+    end
+
+    with_stubbed_smtp(behavior: :auth_error) do
+      post verify_admin_newsletter_path, params: smtp_params, as: :json
+      assert_response :unprocessable_entity
+      assert_equal false, JSON.parse(response.body)["success"]
+    end
+  end
+
+  private
+
+  def with_stubbed_listmonk(configured:, lists:, templates:)
+    original_configured = Listmonk.instance_method(:configured?)
+    original_fetch_lists = Listmonk.instance_method(:fetch_lists)
+    original_fetch_templates = Listmonk.instance_method(:fetch_templates)
+
+    Listmonk.define_method(:configured?) { configured }
+    Listmonk.define_method(:fetch_lists) { lists }
+    Listmonk.define_method(:fetch_templates) { templates }
+    yield
+  ensure
+    Listmonk.define_method(:configured?, original_configured)
+    Listmonk.define_method(:fetch_lists, original_fetch_lists)
+    Listmonk.define_method(:fetch_templates, original_fetch_templates)
+  end
+
+  def with_stubbed_smtp(behavior:)
+    original_new = Net::SMTP.method(:new)
+    fake_class = Class.new do
+      attr_accessor :open_timeout, :read_timeout
+
+      def initialize(behavior)
+        @behavior = behavior
+      end
+
+      def enable_starttls; end
+
+      def start(*_args)
+        case @behavior
+        when :success
+          yield if block_given?
+        when :auth_error
+          raise Net::SMTPAuthenticationError.new("Invalid credentials")
+        else
+          raise Timeout::Error, "timeout"
+        end
+      end
+    end
+
+    Net::SMTP.define_singleton_method(:new) { |_address, _port| fake_class.new(behavior) }
+    yield
+  ensure
+    Net::SMTP.define_singleton_method(:new, original_new)
+  end
 end

--- a/test/controllers/admin/pages_controller_test.rb
+++ b/test/controllers/admin/pages_controller_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+class Admin::PagesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    @page = pages(:draft_page)
+    sign_in(@user)
+  end
+
+  test "admin pages CRUD reorder and batch actions" do
+    get admin_pages_path
+    assert_response :success
+
+    get new_admin_page_path
+    assert_response :success
+
+    get edit_admin_page_path(@page.slug)
+    assert_response :success
+
+    assert_difference "Page.count", 1 do
+      post admin_pages_path, params: {
+        page: {
+          title: "New Page",
+          slug: "new-page",
+          status: "draft",
+          content_type: "html",
+          html_content: "<p>Content</p>"
+        }
+      }
+    end
+    assert_redirected_to admin_pages_path
+
+    post admin_pages_path, params: {
+      page: {
+        title: "",
+        slug: "",
+        status: "draft",
+        content_type: "html",
+        html_content: "<p>Content</p>"
+      }
+    }
+    assert_response :success
+
+    patch admin_page_path(@page.slug), params: { page: { title: "Updated Page" } }
+    assert_redirected_to admin_pages_path
+    assert_equal "Updated Page", @page.reload.title
+
+    patch admin_page_path(@page.slug), params: { page: { title: "" } }
+    assert_response :success
+
+    with_page_insert_at(true) do
+      patch reorder_admin_page_path(@page.slug), params: { position: 1 }
+      assert_response :ok
+    end
+
+    with_page_insert_at(false) do
+      patch reorder_admin_page_path(@page.slug), params: { position: 2 }
+      assert_response :unprocessable_entity
+    end
+
+    post batch_publish_admin_pages_path, params: { ids: [ @page.slug ] }
+    assert_redirected_to admin_pages_path
+    assert @page.reload.publish?
+
+    post batch_unpublish_admin_pages_path, params: { ids: [ @page.slug ] }
+    assert_redirected_to admin_pages_path
+    assert @page.reload.draft?
+
+    delete_page = Page.create!(
+      title: "Delete Page",
+      slug: "delete-page",
+      status: :draft,
+      content_type: :html,
+      html_content: "<p>Content</p>"
+    )
+
+    assert_difference "Page.count", -1 do
+      post batch_destroy_admin_pages_path, params: { ids: [ delete_page.slug ] }
+    end
+
+    assert_difference "Page.count", -1 do
+      delete admin_page_path(@page.slug)
+    end
+  end
+
+  private
+
+  def with_page_insert_at(result)
+    Page.class_eval do
+      define_method(:insert_at) { |_position| result }
+    end
+    yield
+  ensure
+    Page.class_eval do
+      remove_method(:insert_at) if method_defined?(:insert_at)
+    end
+  end
+end

--- a/test/controllers/admin/redirects_controller_test.rb
+++ b/test/controllers/admin/redirects_controller_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class Admin::RedirectsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+    @redirect = Redirect.create!(regex: "old-path", replacement: "/new-path", permanent: false, enabled: true)
+  end
+
+  test "admin redirects CRUD" do
+    get admin_redirects_path
+    assert_response :success
+
+    get new_admin_redirect_path
+    assert_response :success
+
+    assert_difference "Redirect.count", 1 do
+      post admin_redirects_path, params: {
+        redirect: {
+          regex: "^/from",
+          replacement: "/to",
+          permanent: true,
+          enabled: true
+        }
+      }
+    end
+    assert_redirected_to admin_redirects_path
+
+    post admin_redirects_path, params: {
+      redirect: {
+        regex: "(",
+        replacement: "/bad",
+        permanent: false,
+        enabled: true
+      }
+    }
+    assert_response :unprocessable_entity
+
+    get edit_admin_redirect_path(@redirect)
+    assert_response :success
+
+    patch admin_redirect_path(@redirect), params: {
+      redirect: { replacement: "/updated" }
+    }
+    assert_redirected_to admin_redirects_path
+    assert_equal "/updated", @redirect.reload.replacement
+
+    patch admin_redirect_path(@redirect), params: {
+      redirect: { regex: "(" }
+    }
+    assert_response :unprocessable_entity
+
+    assert_difference "Redirect.count", -1 do
+      delete admin_redirect_path(@redirect)
+    end
+    assert_redirected_to admin_redirects_path
+  end
+end

--- a/test/controllers/admin/settings_controller_test.rb
+++ b/test/controllers/admin/settings_controller_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class Admin::SettingsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+    @setting = Setting.first_or_create
+  end
+
+  test "edit and update settings" do
+    get edit_admin_setting_path
+    assert_response :success
+
+    patch admin_setting_path, params: {
+      setting: {
+        title: "Updated Title",
+        url: "https://example.com"
+      }
+    }
+    assert_redirected_to admin_root_path
+    assert_equal "Updated Title", @setting.reload.title
+
+    patch admin_setting_path, params: {
+      setting: {
+        social_links_json: "{"
+      }
+    }
+    assert_response :success
+  end
+end

--- a/test/controllers/admin/sources_controller_test.rb
+++ b/test/controllers/admin/sources_controller_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class Admin::SourcesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+  end
+
+  test "fetch_twitter handles validation and response parsing" do
+    post admin_sources_fetch_twitter_path, params: { url: "" }, as: :json
+    assert_response :unprocessable_entity
+    assert_equal "URL is required", JSON.parse(response.body)["error"]
+
+    post admin_sources_fetch_twitter_path, params: { url: "https://example.com" }, as: :json
+    assert_response :unprocessable_entity
+    assert_equal "Not a valid Twitter/X URL", JSON.parse(response.body)["error"]
+
+    success_body = {
+      html: "<blockquote><p>Hello world</p></blockquote>",
+      author_name: "Tester"
+    }.to_json
+
+    with_stubbed_net_http(response: FakeSuccess.new(success_body)) do
+      post admin_sources_fetch_twitter_path, params: { url: "https://x.com/user/status/1" }, as: :json
+      assert_response :success
+      payload = JSON.parse(response.body)
+      assert_equal true, payload["success"]
+      assert_equal "Tester", payload["author"]
+      assert_equal "Hello world", payload["content"]
+    end
+
+    with_stubbed_net_http(response: Net::HTTPBadRequest.new("1.1", "400", "Bad Request")) do
+      post admin_sources_fetch_twitter_path, params: { url: "https://twitter.com/user/status/1" }, as: :json
+      assert_response :service_unavailable
+      assert_equal "Failed to fetch tweet content", JSON.parse(response.body)["error"]
+    end
+  end
+
+  private
+
+  FakeHttp = Struct.new(:response) do
+    attr_accessor :use_ssl, :open_timeout, :read_timeout
+
+    def request(_request)
+      response
+    end
+  end
+
+  class FakeSuccess < Net::HTTPSuccess
+    def initialize(body)
+      super("1.1", "200", "OK")
+      @read = true
+      @body = body
+    end
+  end
+
+  def with_stubbed_net_http(response:)
+    original_new = Net::HTTP.method(:new)
+    Net::HTTP.define_singleton_method(:new) { |_host, _port| FakeHttp.new(response) }
+    yield
+  ensure
+    Net::HTTP.define_singleton_method(:new, original_new)
+  end
+end

--- a/test/controllers/admin/static_files_controller_test.rb
+++ b/test/controllers/admin/static_files_controller_test.rb
@@ -1,0 +1,82 @@
+require "test_helper"
+
+class Admin::StaticFilesControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    sign_in(@user)
+  end
+
+  test "index create update and destroy static files" do
+    get admin_static_files_path
+    assert_response :success
+
+    post admin_static_files_path, params: { static_file: {} }
+    assert_response :success
+
+    uploaded = fixture_file_upload("sample.txt", "text/plain")
+    assert_difference "StaticFile.count", 1 do
+      post admin_static_files_path, params: {
+        static_file: { file: uploaded, description: "Sample file" }
+      }
+    end
+    assert_redirected_to admin_static_files_path
+
+    static_file = StaticFile.last
+
+    updated_upload = fixture_file_upload("sample.txt", "text/plain")
+    assert_no_difference "StaticFile.count" do
+      post admin_static_files_path, params: {
+        static_file: { file: updated_upload, description: "Updated description" }
+      }
+    end
+    assert_redirected_to admin_static_files_path
+    assert_equal "Updated description", static_file.reload.description
+
+    assert_difference "StaticFile.count", -1 do
+      delete admin_static_file_path(static_file)
+    end
+    assert_redirected_to admin_static_files_path
+  end
+
+  test "renders index when update fails for existing file" do
+    uploaded = fixture_file_upload("sample.txt", "text/plain")
+    static_file = StaticFile.create!(
+      file: uploaded,
+      filename: "sample.txt",
+      description: "Sample"
+    )
+
+    original_find_by = StaticFile.method(:find_by)
+    original_update = static_file.method(:update)
+    StaticFile.define_singleton_method(:find_by) { |_args| static_file }
+    static_file.define_singleton_method(:update) { |_params| false }
+
+    post admin_static_files_path, params: {
+      static_file: { file: uploaded, description: "Updated" }
+    }
+  ensure
+    StaticFile.define_singleton_method(:find_by, original_find_by)
+    static_file.define_singleton_method(:update, original_update)
+
+    assert_response :success
+    assert_match "文件上传失败", response.body
+  end
+
+  test "renders index when new upload fails" do
+    uploaded = fixture_file_upload("sample.txt", "text/plain")
+    failed = StaticFile.new(file: uploaded, filename: "sample.txt", description: "Fail")
+    failed.define_singleton_method(:save) { false }
+
+    original_new = StaticFile.method(:new)
+    StaticFile.define_singleton_method(:new) { |*_args| failed }
+
+    post admin_static_files_path, params: {
+      static_file: { file: uploaded, description: "Fail" }
+    }
+
+    assert_response :success
+    assert_match "文件上传失败", response.body
+  ensure
+    StaticFile.define_singleton_method(:new, original_new)
+  end
+end

--- a/test/controllers/admin/tags_controller_test.rb
+++ b/test/controllers/admin/tags_controller_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class Admin::TagsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+    @tag = tags(:ruby)
+    sign_in(@user)
+  end
+
+  test "admin tags CRUD and batch destroy" do
+    get admin_tags_path
+    assert_response :success
+
+    get new_admin_tag_path
+    assert_response :success
+
+    assert_difference "Tag.count", 1 do
+      post admin_tags_path, params: { tag: { name: "New Tag" } }
+    end
+    assert_redirected_to admin_tags_path
+
+    post admin_tags_path, params: { tag: { name: "" } }
+    assert_response :success
+
+    get edit_admin_tag_path(@tag)
+    assert_response :success
+
+    patch admin_tag_path(@tag), params: { tag: { name: "Updated Tag" } }
+    assert_redirected_to admin_tags_path
+    assert_equal "Updated Tag", @tag.reload.name
+
+    patch admin_tag_path(@tag), params: { tag: { name: "" } }
+    assert_response :success
+
+    article = articles(:published_article)
+    article.tags << @tag unless article.tags.include?(@tag)
+
+    assert_difference "Tag.count", -1 do
+      delete admin_tag_path(@tag)
+    end
+    assert_redirected_to admin_tags_path
+    assert_not_includes article.reload.tags, @tag
+
+    batch_tag = Tag.create!(name: "Batch Tag")
+
+    assert_difference "Tag.count", -1 do
+      post batch_destroy_admin_tags_path, params: { ids: [ batch_tag.id ] }
+    end
+    assert_redirected_to admin_tags_path
+  end
+end

--- a/test/controllers/admin_controller_test.rb
+++ b/test/controllers/admin_controller_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class AdminControllerTest < ActionController::TestCase
+  def setup
+    @user = users(:admin)
+    @controller = AdminController.new
+    session_record = @user.sessions.create!(user_agent: "Test", ip_address: "127.0.0.1")
+    cookies.signed[:session_id] = session_record.id
+  end
+
+  test "posts and pages actions assign filtered collections" do
+    with_routing do |set|
+      set.draw do
+        get "admin/posts" => "admin#posts", as: :admin_posts
+        get "admin/pages" => "admin#pages", as: :admin_pages
+      end
+
+      assert_raises(ActionController::MissingExactTemplate) do
+        get :posts, params: { status: "draft" }
+      end
+
+      assert_raises(ActionController::MissingExactTemplate) do
+        get :pages, params: { status: "all" }
+      end
+    end
+  end
+end

--- a/test/controllers/application_controller_test.rb
+++ b/test/controllers/application_controller_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class ApplicationControllerTest < ActionDispatch::IntegrationTest
+  class DummyController < ApplicationController
+    allow_unauthenticated_access
+
+    def index
+      render plain: "ok"
+    end
+  end
+
+  test "redirects to setup when incomplete and sets time zone when complete" do
+    Setting.first.update!(setup_completed: false)
+
+    with_routing do |set|
+      set.draw do
+        get "/dummy" => "application_controller_test/dummy#index"
+        get "/setup" => "setup#show", as: :setup
+      end
+
+      get "/dummy"
+      assert_redirected_to setup_path
+    end
+
+    Setting.first.update!(setup_completed: true, time_zone: "Asia/Shanghai")
+    CacheableSettings.refresh_site_info
+
+    with_routing do |set|
+      set.draw do
+        get "/dummy" => "application_controller_test/dummy#index"
+      end
+
+      get "/dummy"
+      assert_response :success
+      assert_equal "Asia/Shanghai", Time.zone.name
+    end
+  ensure
+    Time.zone = "UTC"
+  end
+end

--- a/test/controllers/comments_controller_test.rb
+++ b/test/controllers/comments_controller_test.rb
@@ -58,4 +58,210 @@ class CommentsControllerTest < ActionDispatch::IntegrationTest
     assert_select ".flash-notice", false
     assert_select ".comment-form .comment-success-message", /Your comment will be reviewed/
   end
+
+  test "html submit with invalid captcha redirects with alert" do
+    article = articles(:published_article)
+
+    assert_no_difference "Comment.count" do
+      post comments_path(article_id: article.slug), params: {
+        comment: {
+          author_name: "Alice",
+          content: "Nice post!"
+        },
+        captcha: { a: "1", b: "1", op: "+", answer: "" }
+      }
+    end
+
+    assert_redirected_to article_path(article)
+    assert_match "验证失败", flash[:alert]
+  end
+
+  test "creates comment for page with valid captcha" do
+    page = pages(:published_page)
+
+    assert_difference "Comment.count", 1 do
+      post comments_path(page_id: page.slug), params: {
+        comment: {
+          author_name: "Page User",
+          content: "Nice page!"
+        }
+      }.merge(captcha_params), as: :json
+    end
+
+    assert_response :created
+  end
+
+  test "invalid comment returns unprocessable json" do
+    article = articles(:published_article)
+
+    assert_no_difference "Comment.count" do
+      post comments_path(article_id: article.slug), params: {
+        comment: {
+          author_name: "",
+          content: ""
+        }
+      }.merge(captcha_params), as: :json
+    end
+
+    assert_response :unprocessable_entity
+    assert_equal false, response.parsed_body["success"]
+  end
+
+  test "xhr html request returns json on success" do
+    article = articles(:published_article)
+
+    assert_difference "Comment.count", 1 do
+      post comments_path(article_id: article.slug), params: {
+        comment: {
+          author_name: "XHR User",
+          content: "XHR comment"
+        }
+      }.merge(captcha_params), headers: { "X-Requested-With" => "XMLHttpRequest" }
+    end
+
+    assert_response :created
+    assert_includes response.body, "评论已提交"
+  end
+
+  test "unexpected error returns json error" do
+    article = articles(:published_article)
+
+    Comment.class_eval do
+      alias_method :original_save, :save
+      def save(*)
+        raise "boom"
+      end
+    end
+
+    post comments_path(article_id: article.slug), params: {
+      comment: {
+        author_name: "Crash",
+        content: "Crash"
+      }
+    }.merge(captcha_params), as: :json
+
+    assert_response :internal_server_error
+    assert_includes response.body, "提交评论时发生错误"
+  ensure
+    Comment.class_eval do
+      alias_method :save, :original_save
+      remove_method :original_save
+    end
+  end
+
+  test "xhr html request returns json on captcha failure" do
+    article = articles(:published_article)
+
+    post comments_path(article_id: article.slug), params: {
+      comment: {
+        author_name: "XHR User",
+        content: "XHR comment"
+      },
+      captcha: { a: "1", b: "1", op: "+", answer: "" }
+    }, headers: { "X-Requested-With" => "XMLHttpRequest" }
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, "验证失败"
+  end
+
+  test "html invalid comment redirects with alert" do
+    article = articles(:published_article)
+
+    assert_no_difference "Comment.count" do
+      post comments_path(article_id: article.slug), params: {
+        comment: {
+          author_name: "",
+          content: ""
+        }
+      }.merge(captcha_params)
+    end
+
+    assert_redirected_to article_path(article)
+    assert_match "提交评论时出错", flash[:alert]
+  end
+
+  test "html comment on page redirects to page" do
+    page = pages(:published_page)
+
+    assert_difference "Comment.count", 1 do
+      post comments_path(page_id: page.slug), params: {
+        comment: {
+          author_name: "Page Html",
+          content: "Nice page!"
+        }
+      }.merge(captcha_params)
+    end
+
+    assert_redirected_to page_path(page)
+  end
+
+  test "xhr html request returns json on validation error" do
+    article = articles(:published_article)
+
+    assert_no_difference "Comment.count" do
+      post comments_path(article_id: article.slug), params: {
+        comment: {
+          author_name: "",
+          content: ""
+        }
+      }.merge(captcha_params), headers: { "X-Requested-With" => "XMLHttpRequest" }
+    end
+
+    assert_response :unprocessable_entity
+    assert_includes response.body, "提交评论时出错"
+  end
+
+  test "rescues record not found during build" do
+    article = articles(:published_article)
+
+    original_comments = Article.instance_method(:comments)
+    Article.define_method(:comments) { raise ActiveRecord::RecordNotFound }
+
+    post comments_path(article_id: article.slug), params: {
+      comment: {
+        author_name: "Ghost",
+        content: "Missing"
+      }
+    }.merge(captcha_params), as: :json
+
+    assert_response :not_found
+    assert_includes response.body, "文章或页面未找到"
+  ensure
+    Article.define_method(:comments, original_comments)
+  end
+
+  test "xhr html record not found returns json" do
+    article = articles(:published_article)
+    original_comments = Article.instance_method(:comments)
+    Article.define_method(:comments) { raise ActiveRecord::RecordNotFound }
+
+    post comments_path(article_id: article.slug), params: {
+      comment: {
+        author_name: "Ghost",
+        content: "Missing"
+      }
+    }.merge(captcha_params), headers: { "X-Requested-With" => "XMLHttpRequest" }
+
+    assert_response :not_found
+    assert_includes response.body, "文章或页面未找到"
+  ensure
+    Article.define_method(:comments, original_comments)
+  end
+
+  test "html record not found redirects to root" do
+    article = articles(:published_article)
+    original_comments = Article.instance_method(:comments)
+    Article.define_method(:comments) { raise ActiveRecord::RecordNotFound }
+
+    post comments_path(article_id: article.slug), params: {
+      comment: {
+        author_name: "Ghost",
+        content: "Missing"
+      }
+    }.merge(captcha_params)
+
+    assert_redirected_to root_path
+  ensure
+    Article.define_method(:comments, original_comments)
+  end
 end

--- a/test/controllers/passwords_controller_test.rb
+++ b/test/controllers/passwords_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class PasswordsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+  end
+
+  test "password reset requests and updates" do
+    get new_password_path
+    assert_response :success
+
+    assert_enqueued_jobs 1 do
+      post passwords_path, params: { user_name: @user.user_name }
+    end
+    assert_redirected_to new_session_path
+
+    assert_enqueued_jobs 0 do
+      post passwords_path, params: { user_name: "unknown" }
+    end
+    assert_redirected_to new_session_path
+
+    get edit_password_path(1)
+    assert_redirected_to new_session_path
+
+    sign_in(@user)
+    get edit_password_path(1)
+    assert_response :success
+
+    patch password_path(1), params: { password: "mismatch", password_confirmation: "nope" }
+    assert_redirected_to edit_password_path(1)
+
+    patch password_path(1), params: { password: "newpassword", password_confirmation: "newpassword" }
+    assert_redirected_to new_session_path
+    assert @user.reload.authenticate("newpassword")
+  end
+end

--- a/test/controllers/setup_controller_test.rb
+++ b/test/controllers/setup_controller_test.rb
@@ -20,4 +20,63 @@ class SetupControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
     assert_match(/Url can't be blank/, response.body)
   end
+
+  test "setup creates user and settings when valid" do
+    User.delete_all
+    Setting.delete_all
+
+    post setup_path, params: {
+      user: {
+        user_name: "admin",
+        password: "password123",
+        password_confirmation: "password123"
+      },
+      setting: {
+        title: "Test Site",
+        url: "https://example.com",
+        time_zone: "UTC"
+      }
+    }
+
+    assert_redirected_to new_session_path
+    assert User.find_by(user_name: "admin")
+    assert_equal true, Setting.first.setup_completed
+  end
+
+  test "show redirects when setup already completed" do
+    Setting.first_or_create.update!(setup_completed: true, url: "https://example.com")
+
+    get setup_path
+    assert_redirected_to admin_root_path
+  end
+
+  test "setup handles invalid user" do
+    User.delete_all
+    Setting.delete_all
+
+    post setup_path, params: {
+      user: {
+        user_name: "",
+        password: "password123",
+        password_confirmation: "password123"
+      },
+      setting: {
+        title: "Test Site",
+        url: "https://example.com",
+        time_zone: "UTC"
+      }
+    }
+
+    assert_response :unprocessable_entity
+    assert_equal 0, User.count
+  end
+
+  test "show renders when setup incomplete" do
+    User.delete_all
+    Setting.delete_all
+
+    get setup_path
+    assert_response :success
+    assert_select "form"
+  end
 end

--- a/test/controllers/sitemap_controller_test.rb
+++ b/test/controllers/sitemap_controller_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class SitemapControllerTest < ActionDispatch::IntegrationTest
+  test "sitemap returns xml" do
+    sign_in(users(:admin))
+    get sitemap_path(format: :xml)
+    assert_response :success
+    assert_equal "application/xml; charset=utf-8", response.content_type
+    assert_includes response.body, "<urlset"
+  end
+end

--- a/test/controllers/static_files_controller_test.rb
+++ b/test/controllers/static_files_controller_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class StaticFilesControllerTest < ActionDispatch::IntegrationTest
+  test "show redirects to blob when file exists and 404s otherwise" do
+    uploaded = fixture_file_upload("sample.txt", "text/plain")
+    static_file = StaticFile.create!(
+      file: uploaded,
+      filename: "sample.txt",
+      description: "Sample"
+    )
+
+    get static_file_path(filename: static_file.filename)
+    assert_response :redirect
+    assert_includes response.headers["Location"], "/rails/active_storage"
+
+    get static_file_path(filename: "missing.txt")
+    assert_response :not_found
+  end
+end

--- a/test/controllers/tags_controller_test.rb
+++ b/test/controllers/tags_controller_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class TagsControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @tag = tags(:ruby)
+    @article = articles(:published_article)
+    @article.tags << @tag unless @article.tags.include?(@tag)
+  end
+
+  test "index and show tag with rss" do
+    get tags_path
+    assert_response :success
+
+    get tag_path(@tag.slug)
+    assert_response :success
+    assert_includes response.body, @tag.name
+
+    get tag_path(@tag.slug, format: :rss)
+    assert_response :success
+    assert_equal "application/xml; charset=utf-8", response.content_type
+  end
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,50 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  def setup
+    @user = users(:admin)
+  end
+
+  test "new create edit and update user" do
+    get new_user_path
+    assert_redirected_to root_path
+
+    assert_difference "User.count", 1 do
+      post users_path, params: {
+        user: {
+          user_name: "newuser",
+          password: "password123",
+          password_confirmation: "password123"
+        }
+      }
+    end
+    assert_redirected_to new_session_path
+
+    post users_path, params: {
+      user: {
+        user_name: "",
+        password: "password123",
+        password_confirmation: "password123"
+      }
+    }
+    assert_response :success
+
+    sign_in(@user)
+    get edit_user_path(@user)
+    assert_response :success
+
+    patch user_path(@user), params: { user: { user_name: "updateduser" } }
+    assert_redirected_to admin_articles_path
+    assert_equal "updateduser", @user.reload.user_name
+
+    patch user_path(@user), params: { user: { user_name: "" } }
+    assert_response :unprocessable_entity
+  end
+
+  test "new renders form when no users exist" do
+    User.delete_all
+
+    get new_user_path
+    assert_redirected_to setup_path
+  end
+end


### PR DESCRIPTION
Adds controller coverage for admin and public flows, including newsletters, comments, downloads, and setup. Fixes user update redirect to admin articles. Tests not run (not requested).