### PR TITLE
Add model tests for article content and import/export

### DIFF
--- a/test/models/activity_log_test.rb
+++ b/test/models/activity_log_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ActivityLogTest < ActiveSupport::TestCase
+  test "track_activity returns most recent 10 for target and enum is defined" do
+    assert_includes ActivityLog.levels.keys, "info"
+
+    12.times do |index|
+      timestamp = Time.current - index.minutes
+      ActivityLog.create!(
+        action: "event-#{index}",
+        target: "import",
+        level: :info,
+        created_at: timestamp,
+        updated_at: timestamp
+      )
+    end
+
+    results = ActivityLog.track_activity("import")
+    assert_equal 10, results.size
+    assert results.each_cons(2).all? { |a, b| a.created_at >= b.created_at }
+  end
+end

--- a/test/models/article_tag_test.rb
+++ b/test/models/article_tag_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class ArticleTagTest < ActiveSupport::TestCase
+  test "enforces unique article/tag pair" do
+    article = articles(:published_article)
+    tag = tags(:ruby)
+
+    ArticleTag.create!(article: article, tag: tag)
+    duplicate = ArticleTag.new(article: article, tag: tag)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:article_id], "has already been taken"
+  end
+end

--- a/test/models/concerns/active_storage_compression_test.rb
+++ b/test/models/concerns/active_storage_compression_test.rb
@@ -1,0 +1,55 @@
+require "test_helper"
+require "minitest/mock"
+
+class ActiveStorageCompressionTest < ActiveSupport::TestCase
+  test "compresses only embed image attachments" do
+    article = articles(:published_article)
+    rich_text = ActionText::RichText.create!(record: article, name: "content", body: "<p>Hi</p>")
+
+    image_blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("fake-image"),
+      filename: "image.png",
+      content_type: "image/png"
+    )
+    text_blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("fake-text"),
+      filename: "file.txt",
+      content_type: "text/plain"
+    )
+
+    image_attachment = ActiveStorage::Attachment.create!(name: "embeds", record: rich_text, blob: image_blob)
+    non_embed_attachment = ActiveStorage::Attachment.create!(name: "other", record: rich_text, blob: image_blob)
+    non_image_attachment = ActiveStorage::Attachment.create!(name: "embeds", record: rich_text, blob: text_blob)
+
+    image_attachment.stub(:compress_image, true) do
+      assert image_attachment.send(:image_attachment?)
+      image_attachment.send(:compress_trix_image)
+    end
+
+    non_embed_attachment.stub(:compress_image, -> { flunk("should not compress non-embeds") }) do
+      non_embed_attachment.send(:compress_trix_image)
+    end
+
+    non_image_attachment.stub(:compress_image, -> { flunk("should not compress non-image") }) do
+      non_image_attachment.send(:compress_trix_image)
+    end
+
+    unless defined?(Vips)
+      Object.const_set(:Vips, Module.new)
+      Vips.const_set(:Image, Class.new)
+    end
+
+    fake_vips = Class.new do
+      def write_to_file(path, **_kwargs)
+        File.write(path, "compressed")
+      end
+    end.new
+
+    Vips::Image.stub(:new_from_file, fake_vips) do
+      image_attachment.send(:compress_image)
+    end
+
+    original_path = image_attachment.blob.service.path_for(image_attachment.blob.key)
+    assert_equal File.size(original_path), image_attachment.blob.reload.byte_size
+  end
+end

--- a/test/models/concerns/cacheable_settings_test.rb
+++ b/test/models/concerns/cacheable_settings_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+require "minitest/mock"
+
+class CacheableSettingsTest < ActiveSupport::TestCase
+  test "caches site info and navbar items with refresh helpers" do
+    Rails.cache.clear
+
+    info = CacheableSettings.site_info
+    assert_equal settings(:default).title, info[:title]
+    assert_equal settings(:default).url, info[:url]
+
+    items = CacheableSettings.navbar_items
+    assert_equal [ pages(:page_with_script).id, pages(:published_page).id ], items.map(&:id)
+
+    Setting.stub(:first, nil) do
+      Rails.cache.delete("site_info")
+      assert_equal({}, CacheableSettings.site_info)
+    end
+
+    CacheableSettings.refresh_all
+    assert_nil Rails.cache.read("site_info")
+    assert_nil Rails.cache.read("navbar_items")
+  end
+end

--- a/test/models/concerns/html_attachment_processing_test.rb
+++ b/test/models/concerns/html_attachment_processing_test.rb
@@ -1,0 +1,60 @@
+require "test_helper"
+require "minitest/mock"
+require "ostruct"
+
+class HtmlAttachmentProcessingTest < ActiveSupport::TestCase
+  class Harness
+    include Exports::HtmlAttachmentProcessing
+    attr_reader :attachments_dir
+
+    def initialize(attachments_dir)
+      @attachments_dir = attachments_dir
+    end
+  end
+
+  test "builds full urls and resolves filenames/extensions" do
+    Dir.mktmpdir do |dir|
+      processor = Harness.new(dir)
+
+      Setting.stub(:table_exists?, true) do
+        Setting.stub(:first, OpenStruct.new(url: "http://example.com")) do
+          assert_equal "http://example.com/relative.png", processor.send(:build_full_url, "relative.png")
+          assert_equal "http://example.com/absolute.png", processor.send(:build_full_url, "/absolute.png")
+        end
+      end
+
+      processor.stub(:detect_extension_from_content_type, ".png") do
+        filename = processor.send(:extract_filename_from_url, "http://example.com/noext")
+        assert_match(/\.png\z/, filename)
+      end
+
+      invalid_filename = processor.send(:extract_filename_from_url, "http://\n")
+      assert_match(/\.jpg\z/, invalid_filename)
+
+      head_response = Net::HTTPOK.new("1.1", "200", "OK")
+      head_response["Content-Type"] = "image/webp"
+      head_response.instance_variable_set(:@read, true)
+      http = Struct.new(:response) { def head(_url) response end }.new(head_response)
+      Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+        assert_equal ".webp", processor.send(:detect_extension_from_content_type, "http://example.com/img.webp")
+      end
+    end
+  end
+
+  test "downloads active storage attachments to the export directory" do
+    Dir.mktmpdir do |dir|
+      processor = Harness.new(dir)
+      blob = ActiveStorage::Blob.create_and_upload!(
+        io: StringIO.new("blob"),
+        filename: "blob.png",
+        content_type: "image/png"
+      )
+      blob_url = Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
+
+      result = processor.send(:download_and_save_attachment, blob_url, "blob.png", 1, "article")
+      assert_equal true, result.start_with?("attachments/article_1/")
+      local_path = File.join(dir, "article_1", File.basename(result))
+      assert File.exist?(local_path)
+    end
+  end
+end

--- a/test/models/crosspost_test.rb
+++ b/test/models/crosspost_test.rb
@@ -26,6 +26,22 @@ class CrosspostTest < ActiveSupport::TestCase
     assert crosspost.valid?
   end
 
+  test "uses platform defaults for max characters and enforces credentials when enabled" do
+    mastodon = Crosspost.new(platform: "mastodon", enabled: false)
+    twitter = Crosspost.new(platform: "twitter", enabled: false, max_characters: 111)
+    bluesky = Crosspost.new(platform: "bluesky", enabled: false)
+
+    assert_equal 500, mastodon.default_max_characters
+    assert_equal 250, twitter.default_max_characters
+    assert_equal 300, bluesky.default_max_characters
+    assert_equal 111, twitter.effective_max_characters
+    assert_equal 500, mastodon.effective_max_characters
+
+    mastodon.enabled = true
+    assert_not mastodon.valid?
+    assert_includes mastodon.errors[:client_key], "can't be blank"
+  end
+
   private
 
   def build_crosspost(server_url)

--- a/test/models/current_test.rb
+++ b/test/models/current_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class CurrentTest < ActiveSupport::TestCase
+  test "delegates user through session and allows nil" do
+    Current.session = Session.new(user: users(:admin))
+    assert_equal users(:admin), Current.user
+
+    Current.session = nil
+    assert_nil Current.user
+  ensure
+    Current.reset
+  end
+end

--- a/test/models/export_test.rb
+++ b/test/models/export_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/mock"
 
 class ExportTest < ActiveSupport::TestCase
   test "exports article source reference and seo fields" do
@@ -56,5 +57,203 @@ class ExportTest < ActiveSupport::TestCase
     end
   ensure
     File.delete(exporter.zip_path) if exporter&.zip_path.present? && File.exist?(exporter.zip_path)
+  end
+
+  test "processes html attachments and remote images" do
+    exporter = Export.new
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("blob-data"),
+      filename: "blob.png",
+      content_type: "image/png"
+    )
+    blob_url = Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
+
+    html = <<~HTML
+      <p>Intro</p>
+      <action-text-attachment content-type="image/png" url="#{blob_url}" filename="blob.png"></action-text-attachment>
+      <figure data-trix-attachment='{"contentType":"image/png","url":"http://example.com/figure.jpg","filename":"figure.jpg"}' data-trix-attributes='{"caption":"Figure"}'></figure>
+      <img src="http://example.com/remote.jpg">
+      <img src="http://example.com/remote">
+      <img src="/uploads/relative.jpg">
+    HTML
+
+    head_response = Net::HTTPOK.new("1.1", "200", "OK")
+    head_response["Content-Type"] = "image/png"
+    head_response.instance_variable_set(:@read, true)
+    http = Struct.new(:response) { def head(_url) response end }.new(head_response)
+
+    uri_stub = lambda do |_url, **_kwargs, &block|
+      io = StringIO.new("remote-image")
+      block ? block.call(io) : io
+    end
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+      URI.stub(:open, uri_stub) do
+        processed = exporter.process_html_content(html, record_id: 1, record_type: "article")
+        assert_includes processed, "attachments/article_1"
+        assert Dir.exist?(exporter.attachments_dir)
+      end
+    end
+  ensure
+    FileUtils.rm_rf(exporter.export_dir) if exporter&.export_dir
+  end
+
+  test "exports rich text content and related records" do
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("blob-data"),
+      filename: "blob.png",
+      content_type: "image/png"
+    )
+    attachment = ActionText::Attachment.from_attachable(blob)
+    rich_article = Article.create!(
+      title: "Rich Export",
+      slug: "rich-export-#{SecureRandom.hex(4)}",
+      status: :publish,
+      content: "<p>Body</p>#{attachment.to_html}"
+    )
+
+    tag = Tag.create!(name: "Export Tag #{SecureRandom.hex(3)}", slug: "export-tag-#{SecureRandom.hex(3)}")
+    ArticleTag.create!(article: rich_article, tag: tag)
+
+    subscriber = Subscriber.create!(
+      email: "export-#{SecureRandom.hex(4)}@example.com",
+      confirmation_token: SecureRandom.urlsafe_base64(32),
+      unsubscribe_token: SecureRandom.urlsafe_base64(32)
+    )
+    SubscriberTag.create!(subscriber: subscriber, tag: tag)
+
+    SocialMediaPost.create!(article: rich_article, platform: "twitter", url: "https://example.com/post")
+    Redirect.create!(regex: "^/export$", replacement: "/exported", enabled: true, permanent: false)
+
+    static_file = StaticFile.new(filename: "export.txt", description: "export")
+    file = File.open(Rails.root.join("test/fixtures/files/sample.txt"))
+    static_file.file.attach(io: file, filename: "export.txt", content_type: "text/plain")
+    static_file.save!
+    file.close
+
+    newsletter_setting = NewsletterSetting.create!(provider: "native", enabled: false)
+    newsletter_setting.update!(footer: "<p>Footer</p>")
+
+    exporter = Export.new
+    assert exporter.generate, exporter.error_message
+
+    Zip::File.open(exporter.zip_path) do |zip|
+      assert zip.find_entry("static_files.csv")
+      assert zip.find_entry("newsletter_settings.csv")
+      assert zip.find_entry("social_media_posts.csv")
+      assert zip.find_entry("subscriber_tags.csv")
+    end
+  ensure
+    File.delete(exporter.zip_path) if exporter&.zip_path.present? && File.exist?(exporter.zip_path)
+  end
+
+  test "handles export failures and activity log export" do
+    ActiveRecord::Base.connection.stub(:execute, ->(_sql) { raise "db down" }) do
+      failing_exporter = Export.new
+      assert_not failing_exporter.check_database_connection
+      assert_match "Database connection failed", failing_exporter.error_message
+      FileUtils.rm_rf(failing_exporter.export_dir) if failing_exporter.export_dir
+    end
+
+    ActivityLog.create!(action: "test", target: "export", level: :info, description: "log")
+    exporter = Export.new
+    exporter.send(:export_activity_logs)
+    assert File.exist?(File.join(exporter.export_dir, "activity_logs.csv"))
+
+    exporter.stub(:export_articles, -> { raise "boom" }) do
+      assert_not exporter.generate
+      assert_match "boom", exporter.error_message
+    end
+  ensure
+    FileUtils.rm_rf(exporter.export_dir) if exporter&.export_dir
+  end
+
+  test "processes attachment nodes and fallback article content" do
+    exporter = Export.new
+    exporter.stub(:download_and_save_attachment, "attachments/test.png") do
+      attachment = Nokogiri::HTML.fragment(
+        "<action-text-attachment content-type=\"image/png\" url=\"http://example.com/a.png\" filename=\"a.png\" caption=\"Cap\"><img></action-text-attachment>"
+      ).at_css("action-text-attachment")
+      exporter.send(:process_attachment_element, attachment, 1, "article")
+      assert_equal "attachments/test.png", attachment["url"]
+      assert_equal "Cap", attachment.at_css("img")["alt"]
+
+      fragment = Nokogiri::HTML.fragment(
+        "<action-text-attachment content-type=\"image/png\" url=\"http://example.com/a.png\" filename=\"a.png\"></action-text-attachment>"
+      )
+      attachment_no_img = fragment.at_css("action-text-attachment")
+      exporter.send(:process_attachment_element, attachment_no_img, 1, "article")
+      assert_includes fragment.to_html, "<img"
+
+      figure_json = { contentType: "image/png", url: "http://example.com/f.png", filename: "f.png" }.to_json
+      figure = Nokogiri::HTML.fragment("<figure data-trix-attachment='#{figure_json}' data-trix-attributes='{\"caption\":\"Fig\"}'></figure>").at_css("figure")
+      exporter.send(:process_figure_element, figure, 1, "article")
+      assert_includes figure.to_html, "<img"
+    end
+
+    empty_rich_article = Article.new(content_type: :rich_text)
+    assert_equal "", exporter.send(:process_article_content, empty_rich_article)
+  ensure
+    FileUtils.rm_rf(exporter.export_dir) if exporter&.export_dir
+  end
+
+  test "skips static files without attachments" do
+    static_file = StaticFile.new(filename: "missing.txt")
+    static_file.save!(validate: false)
+
+    exporter = Export.new
+    exporter.send(:export_static_files)
+
+    csv_path = File.join(exporter.export_dir, "static_files.csv")
+    assert File.exist?(csv_path)
+    assert_equal 1, File.readlines(csv_path).size
+
+    attachments_path = File.join(exporter.attachments_dir, "static_files")
+    refute Dir.exist?(attachments_path)
+  ensure
+    FileUtils.rm_rf(exporter.export_dir) if exporter&.export_dir
+    static_file&.delete
+  end
+
+  test "cleans up old export and import files" do
+    exports_dir = Rails.root.join("tmp", "exports")
+    uploads_dir = Rails.root.join("tmp", "uploads")
+    FileUtils.mkdir_p(exports_dir)
+    FileUtils.mkdir_p(uploads_dir)
+
+    export_file = exports_dir.join("export_old.zip")
+    markdown_file = exports_dir.join("markdown_export_old.zip")
+    import_file = uploads_dir.join("import_old.zip")
+
+    past_time = 2.days.ago.to_time
+    [ export_file, markdown_file, import_file ].each do |file|
+      File.write(file, "data")
+      File.utime(past_time, past_time, file)
+    end
+
+    result = Export.cleanup_old_exports(days: 1)
+
+    assert_equal 3, result[:deleted]
+    assert_equal 0, result[:errors]
+    refute File.exist?(export_file)
+    refute File.exist?(markdown_file)
+    refute File.exist?(import_file)
+    assert_match(/Cleaned up 3 old export\/import file/, result[:message])
+  ensure
+    FileUtils.rm_rf(exports_dir)
+    FileUtils.rm_rf(uploads_dir)
+  end
+
+  test "exports users to csv" do
+    exporter = Export.new
+    exporter.send(:export_users)
+
+    csv_path = File.join(exporter.export_dir, "users.csv")
+    assert File.exist?(csv_path)
+    content = File.read(csv_path)
+    assert_includes content, "user_name"
+    assert_includes content, "admin"
+  ensure
+    FileUtils.rm_rf(exporter.export_dir) if exporter&.export_dir
   end
 end

--- a/test/models/import_rss_test.rb
+++ b/test/models/import_rss_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+require "ostruct"
+require "minitest/mock"
+
+class ImportRssTest < ActiveSupport::TestCase
+  test "imports entries, handles images, and records errors" do
+    feed_url = "https://feed.example.com/rss"
+    image_url = "https://example.com/image.png"
+
+    entry = OpenStruct.new(
+      url: "https://example.com/posts/hello-world",
+      title: "Hello World",
+      published: Time.current,
+      content: "<p>Body</p><img src=\"#{image_url}\">",
+      summary: "Summary"
+    )
+    feed = OpenStruct.new(entries: [ entry ])
+
+    image_io_builder = lambda do
+      io = StringIO.new("image-data")
+      io.define_singleton_method(:content_type) { "image/png" }
+      io
+    end
+
+    URI.stub(:open, lambda { |url, &block|
+      if url == feed_url
+        StringIO.new("feed-data")
+      else
+        io = image_io_builder.call
+        block ? block.call(io) : io
+      end
+    }) do
+      Feedjira.stub(:parse, feed) do
+        importer = ImportRss.new(feed_url, true)
+        assert_difference "Article.count", 1 do
+          assert importer.import_data
+        end
+      end
+    end
+
+    URI.stub(:open, lambda { |_url, &block|
+      io = StringIO.new("feed-data")
+      block ? block.call(io) : io
+    }) do
+      Feedjira.stub(:parse, ->(_data) { raise StandardError, "boom" }) do
+        importer = ImportRss.new(feed_url)
+        assert_not importer.import_data
+        assert_match(/boom/, importer.error_message)
+      end
+    end
+  end
+end

--- a/test/models/import_zip_test.rb
+++ b/test/models/import_zip_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/mock"
 
 class ImportZipTest < ActiveSupport::TestCase
   test "imports article source reference and seo fields" do
@@ -297,6 +298,368 @@ class ImportZipTest < ActiveSupport::TestCase
     assert redirect.permanent?, "expected redirect to be marked permanent when permanent is 1"
   ensure
     File.delete(zip_path) if zip_path.present? && File.exist?(zip_path)
+  end
+
+  test "imports a full dataset with attachments" do
+    ArticleTag.delete_all
+    SubscriberTag.delete_all
+    SocialMediaPost.delete_all
+    Comment.delete_all
+    Tag.delete_all
+    Article.delete_all
+    Subscriber.delete_all
+    Page.delete_all
+    StaticFile.delete_all
+    Redirect.delete_all
+    Setting.delete_all
+    NewsletterSetting.delete_all
+    Crosspost.delete_all
+    GitIntegration.delete_all
+    Listmonk.delete_all
+
+    tag_slug = "tag-#{SecureRandom.hex(4)}"
+    article_slug = "article-#{SecureRandom.hex(4)}"
+    page_slug = "page-#{SecureRandom.hex(4)}"
+    subscriber_email = "subscriber-#{SecureRandom.hex(4)}@example.com"
+
+    attachment_json = {
+      "contentType" => "image/png",
+      "url" => "attachments/article_1/figure.png",
+      "filename" => "figure.png"
+    }.to_json
+
+    article_content = <<~HTML.squish
+      <p>Hello</p>
+      <action-text-attachment content-type="image/png" url="attachments/article_1/inline.png" filename="inline.png"></action-text-attachment>
+      <figure data-trix-attachment='#{attachment_json}'></figure>
+      <img src="attachments/article_1/image.png">
+    HTML
+
+    tags_csv = CSV.generate(write_headers: true, headers: %w[id name slug created_at updated_at]) do |csv|
+      csv << [ 1, "Tag", tag_slug, Time.current, Time.current ]
+    end
+
+    articles_csv = CSV.generate(write_headers: true, headers: %w[
+      id title slug description content status scheduled_at
+      source_url source_author source_content
+      meta_title meta_description meta_image
+      content_type html_content comment
+      created_at updated_at
+    ]) do |csv|
+      csv << [
+        1,
+        "Imported Article",
+        article_slug,
+        "desc",
+        article_content,
+        "publish",
+        nil,
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "rich_text",
+        "",
+        "false",
+        Time.current,
+        Time.current
+      ]
+    end
+
+    article_tags_csv = CSV.generate(write_headers: true, headers: %w[id article_slug tag_slug created_at updated_at]) do |csv|
+      csv << [ 1, article_slug, tag_slug, Time.current, Time.current ]
+    end
+
+    crossposts_csv = CSV.generate(
+      write_headers: true,
+      headers: %w[id platform server_url client_key client_secret access_token access_token_secret api_key api_key_secret username app_password enabled auto_fetch_comments comment_fetch_schedule max_characters settings created_at updated_at]
+    ) do |csv|
+      csv << [
+        1,
+        "mastodon",
+        "https://mastodon.example.com",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "true",
+        "false",
+        "",
+        "",
+        "{}",
+        Time.current,
+        Time.current
+      ]
+    end
+
+    listmonks_csv = CSV.generate(write_headers: true, headers: %w[id url username api_key list_id template_id enabled created_at updated_at]) do |csv|
+      csv << [ 1, "https://listmonk.example.com", "user", "key", 1, 2, "true", Time.current, Time.current ]
+    end
+
+    git_integrations_csv = CSV.generate(write_headers: true, headers: %w[id provider name server_url username access_token enabled created_at updated_at]) do |csv|
+      csv << [ 1, "github", "GitHub", "https://github.com", "user", "", "true", Time.current, Time.current ]
+    end
+
+    pages_csv = CSV.generate(write_headers: true, headers: %w[id title slug content status redirect_url page_order content_type html_content created_at updated_at]) do |csv|
+      csv << [
+        1,
+        "Imported Page",
+        page_slug,
+        "<p>Page</p><img src=\"attachments/page_1/image.png\">",
+        "publish",
+        "",
+        1,
+        "html",
+        "",
+        Time.current,
+        Time.current
+      ]
+    end
+
+    settings_csv = CSV.generate(write_headers: true, headers: %w[
+      id title description author url time_zone giscus tool_code head_code custom_css
+      social_links static_files auto_regenerate_triggers deploy_branch deploy_provider deploy_repo_url
+      local_generation_path static_generation_destination static_generation_delay setup_completed
+      github_backup_enabled github_repo_url github_token github_backup_branch created_at updated_at
+    ]) do |csv|
+      csv << [
+        1,
+        "Imported Site",
+        "desc",
+        "Author",
+        "http://example.com",
+        "UTC",
+        "",
+        "",
+        "",
+        "",
+        "{invalid",
+        "{}",
+        "{invalid",
+        "main",
+        "",
+        "",
+        "",
+        "local",
+        "",
+        "true",
+        "false",
+        "",
+        "",
+        "main",
+        Time.current,
+        Time.current
+      ]
+    end
+
+    setting_footers_csv = CSV.generate(write_headers: true, headers: %w[content]) do |csv|
+      csv << [ "<p>Footer</p><img src=\"attachments/setting_1/footer.png\">" ]
+    end
+
+    social_media_posts_csv = CSV.generate(write_headers: true, headers: %w[id article_slug platform url created_at updated_at]) do |csv|
+      csv << [ 1, article_slug, "twitter", "https://example.com/post", Time.current, Time.current ]
+    end
+
+    comments_csv = CSV.generate(
+      write_headers: true,
+      headers: %w[id article_id article_slug parent_id author_name author_url author_username author_avatar_url content platform external_id status published_at url created_at updated_at]
+    ) do |csv|
+      csv << [ 1, "", article_slug, "", "Parent", "", "", "", "Parent comment", "", "", "approved", "", "", Time.current, Time.current ]
+      csv << [ 2, "", article_slug, 1, "Child", "", "", "", "Child comment", "twitter", "ext-1", "approved", "", "", Time.current, Time.current ]
+    end
+
+    static_files_csv = CSV.generate(write_headers: true, headers: %w[id filename description blob_filename created_at updated_at]) do |csv|
+      csv << [ 1, "static.txt", "Static file", "static.txt", Time.current, Time.current ]
+    end
+
+    redirects_csv = CSV.generate(write_headers: true, headers: %w[id regex replacement enabled permanent created_at updated_at]) do |csv|
+      csv << [ 1, "^/imported$", "/target", "true", "false", Time.current, Time.current ]
+    end
+
+    newsletter_settings_csv = CSV.generate(
+      write_headers: true,
+      headers: %w[id provider enabled smtp_address smtp_port smtp_user_name smtp_password smtp_domain smtp_authentication smtp_enable_starttls from_email footer created_at updated_at]
+    ) do |csv|
+      csv << [
+        1,
+        "native",
+        "true",
+        "smtp.example.com",
+        587,
+        "user",
+        "pass",
+        "",
+        "plain",
+        "true",
+        "from@example.com",
+        "<p>Newsletter</p><img src=\"attachments/newsletter_setting_1/footer.png\">",
+        Time.current,
+        Time.current
+      ]
+    end
+
+    subscribers_csv = CSV.generate(write_headers: true, headers: %w[id email confirmation_token confirmed_at unsubscribe_token unsubscribed_at created_at updated_at]) do |csv|
+      csv << [ 1, subscriber_email, "token", Time.current, "unsub", "", Time.current, Time.current ]
+    end
+
+    subscriber_tags_csv = CSV.generate(write_headers: true, headers: %w[id subscriber_email tag_slug created_at updated_at]) do |csv|
+      csv << [ 1, subscriber_email, tag_slug, Time.current, Time.current ]
+    end
+
+    zip_path = build_zip(
+      "tags.csv" => tags_csv,
+      "articles.csv" => articles_csv,
+      "article_tags.csv" => article_tags_csv,
+      "crossposts.csv" => crossposts_csv,
+      "listmonks.csv" => listmonks_csv,
+      "git_integrations.csv" => git_integrations_csv,
+      "pages.csv" => pages_csv,
+      "settings.csv" => settings_csv,
+      "setting_footers.csv" => setting_footers_csv,
+      "social_media_posts.csv" => social_media_posts_csv,
+      "comments.csv" => comments_csv,
+      "static_files.csv" => static_files_csv,
+      "redirects.csv" => redirects_csv,
+      "newsletter_settings.csv" => newsletter_settings_csv,
+      "subscribers.csv" => subscribers_csv,
+      "subscriber_tags.csv" => subscriber_tags_csv,
+      "attachments/article_1/inline.png" => "inline",
+      "attachments/article_1/figure.png" => "figure",
+      "attachments/article_1/image.png" => "image",
+      "attachments/page_1/image.png" => "page",
+      "attachments/setting_1/footer.png" => "footer",
+      "attachments/newsletter_setting_1/footer.png" => "newsletter",
+      "attachments/static_files/1_static.txt" => "static"
+    )
+
+    importer = ImportZip.new(zip_path)
+
+    assert importer.import_data, importer.error_message
+    assert Article.find_by!(slug: article_slug)
+    assert Page.find_by!(slug: page_slug)
+    assert Tag.find_by!(slug: tag_slug)
+    assert ArticleTag.find_by!(tag_id: Tag.find_by!(slug: tag_slug).id)
+    assert SocialMediaPost.find_by!(platform: "twitter")
+    assert Comment.find_by!(author_name: "Child")
+    assert StaticFile.find_by!(filename: "static.txt")
+    assert Redirect.find_by!(regex: "^/imported$")
+    assert NewsletterSetting.first
+    assert Subscriber.find_by!(email: subscriber_email)
+    assert SubscriberTag.find_by!(subscriber_id: Subscriber.find_by!(email: subscriber_email).id)
+
+    blob = ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("blob"),
+      filename: "blob.png",
+      content_type: "image/png"
+    )
+    blob_url = Rails.application.routes.url_helpers.rails_blob_path(blob, only_path: true)
+    assert_equal blob, importer.send(:extract_blob_from_url, blob_url)
+    assert_equal ".png", importer.send(:extract_extension_from_url, "http://example.com/image.png")
+    assert_nil importer.send(:extract_extension_from_url, "http://example.com/noext")
+
+    head_response = Net::HTTPOK.new("1.1", "200", "OK")
+    head_response["Content-Type"] = "image/png"
+    head_response.instance_variable_set(:@read, true)
+    http = Struct.new(:response) { def head(_url) response end }.new(head_response)
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+      assert_equal "image/png", importer.send(:detect_content_type_from_url, "http://example.com/image.png")
+    end
+
+    img_node = Nokogiri::HTML.fragment("<img src=\"http://example.com/remote.png\">").at_css("img")
+    uri_stub = lambda do |_url, **_kwargs, &block|
+      io = StringIO.new("remote")
+      block ? block.call(io) : io
+    end
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+      URI.stub(:open, uri_stub) do
+        importer.send(:download_and_process_remote_image, img_node, "http://example.com/remote.png", "rec", "type")
+        assert_includes img_node["src"], "/rails/active_storage/blobs/"
+      end
+    end
+
+    importer.send(:safe_process) { raise "boom" }
+
+    Comment.where.not(platform: nil).delete_all
+    second_importer = ImportZip.new(zip_path)
+    assert second_importer.import_data, second_importer.error_message
+
+    attachment_node = Nokogiri::HTML.fragment(
+      "<action-text-attachment content-type=\"image/png\" url=\"#{blob_url}\" filename=\"#{blob.filename}\"></action-text-attachment>"
+    ).at_css("action-text-attachment")
+    importer.send(:process_imported_attachment_element, attachment_node, "rec", "attachment")
+    assert_includes attachment_node["url"], "/rails/active_storage/blobs/"
+
+    figure_json = {
+      "contentType" => "image/png",
+      "url" => blob_url,
+      "filename" => blob.filename.to_s
+    }.to_json
+    figure_node = Nokogiri::HTML.fragment("<figure data-trix-attachment='#{figure_json}'></figure>").at_css("figure")
+    importer.send(:process_imported_figure_element, figure_node, "rec", "figure")
+    assert_includes figure_node["data-trix-attachment"], "/rails/active_storage/blobs/"
+
+    img_node = Nokogiri::HTML.fragment("<img src=\"#{blob_url}\">").at_css("img")
+    importer.send(:process_imported_image_element, img_node, "rec", "image")
+    assert_includes img_node["src"], "/rails/active_storage/blobs/"
+
+    fix_content = "<action-text-attachment filename=\"#{blob.filename}\" sgid=\"bad\" url=\"#{blob_url}\"></action-text-attachment>"
+    fixed = importer.send(:fix_content_sgid_references, fix_content)
+    refute_includes fixed, 'sgid="bad"'
+    assert_includes fixed, "/rails/active_storage/blobs/redirect/"
+
+    missing_attachment = Nokogiri::HTML.fragment(
+      "<action-text-attachment content-type=\"image/png\" url=\"attachments/missing.png\" filename=\"missing.png\"></action-text-attachment>"
+    ).at_css("action-text-attachment")
+    importer.send(:process_imported_attachment_element, missing_attachment, "rec", "attachment")
+
+    missing_figure_json = { "contentType" => "image/png", "url" => "attachments/missing.png", "filename" => "missing.png" }.to_json
+    missing_figure = Nokogiri::HTML.fragment("<figure data-trix-attachment='#{missing_figure_json}'></figure>").at_css("figure")
+    importer.send(:process_imported_figure_element, missing_figure, "rec", "figure")
+
+    missing_img = Nokogiri::HTML.fragment("<img src=\"attachments/missing.png\">").at_css("img")
+    importer.send(:process_imported_image_element, missing_img, "rec", "image")
+
+    assert_nil importer.send(:extract_blob_from_url, "/rails/active_storage/blobs/redirect/bad-signed-id")
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { raise "boom" }) do
+      assert_equal "image/jpeg", importer.send(:detect_content_type_from_url, "http://example.com/image.png")
+    end
+
+    assert importer.send(:safe_file_path?, importer.import_dir.join("ok.txt"))
+    refute importer.send(:safe_file_path?, Rails.root.join("tmp/outside.txt"))
+  ensure
+    File.delete(zip_path) if zip_path.present? && File.exist?(zip_path)
+  end
+
+  test "helper utilities handle json, booleans, and path checks" do
+    zip_path = build_zip("tags.csv" => "id,name\n")
+    importer = ImportZip.new(zip_path)
+
+    assert_nil importer.send(:parse_json_field, "")
+    assert_equal({}, importer.send(:parse_json_field, "{invalid"))
+    assert_nil importer.send(:parse_json_field, "null")
+
+    assert_equal true, importer.send(:cast_boolean, "true", default: false)
+    assert_equal false, importer.send(:cast_boolean, nil, default: false)
+    assert_equal true, importer.send(:cast_boolean, nil, default: true)
+
+    assert importer.send(:is_local_attachment?, "attachments/file.png")
+    refute importer.send(:is_local_attachment?, "http://example.com/file.png")
+    assert importer.send(:is_active_storage_url?, "/rails/active_storage/blobs/redirect/abc")
+
+    other_base = Rails.root.join("tmp")
+    assert_equal File.join(other_base, "path.txt"), importer.send(:safe_join_path, other_base, "path.txt")
+  ensure
+    File.delete(zip_path) if zip_path.present? && File.exist?(zip_path)
+    FileUtils.rm_rf(importer.import_dir) if importer&.import_dir
   end
 
   private

--- a/test/models/listmonk_test.rb
+++ b/test/models/listmonk_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "minitest/mock"
 
 class ListmonkTest < ActiveSupport::TestCase
   test "campaign_body includes source reference before content when article has source" do
@@ -22,5 +23,161 @@ class ListmonkTest < ActiveSupport::TestCase
 
     refute_includes body, "source-reference__quote"
     assert_includes body, "<p>Published article content</p>"
+  end
+
+  test "fetches lists/templates and sends newsletters through the api" do
+    listmonk = Listmonk.create!(
+      url: "https://listmonk.example.com",
+      username: "user",
+      api_key: "key",
+      list_id: 1,
+      template_id: 2
+    )
+    assert listmonk.configured?
+    assert_not Listmonk.new.configured?
+
+    lists_response = Net::HTTPOK.new("1.1", "200", "OK")
+    lists_response.body = { data: { results: [ { "id" => 10 } ] } }.to_json
+    lists_response.instance_variable_set(:@read, true)
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { lists_response }) do
+      assert_equal [ { "id" => 10 } ], listmonk.fetch_lists
+    end
+
+    templates_response = Net::HTTPBadRequest.new("1.1", "400", "Bad")
+    templates_response.body = "{}"
+    templates_response.instance_variable_set(:@read, true)
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { templates_response }) do
+      assert_equal [], listmonk.fetch_templates
+    end
+
+    create_response = Net::HTTPOK.new("1.1", "200", "OK")
+    create_response.body = { data: { id: 123 } }.to_json
+    create_response.instance_variable_set(:@read, true)
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { create_response }) do
+      assert_equal 123, listmonk.create_campaigns(articles(:published_article), "Site")
+    end
+
+    send_response = Net::HTTPOK.new("1.1", "200", "OK")
+    send_response.body = "{}"
+    send_response.instance_variable_set(:@read, true)
+    listmonk.stub(:create_campaigns, 123) do
+      Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { send_response }) do
+        assert_equal true, listmonk.send_newsletter(articles(:published_article), "Site")
+      end
+    end
+
+    listmonk.stub(:create_campaigns, nil) do
+      assert_equal false, listmonk.send_newsletter(articles(:published_article), "Site")
+    end
+
+    bad_response = Net::HTTPBadRequest.new("1.1", "400", "Bad")
+    bad_response.body = "{}"
+    bad_response.instance_variable_set(:@read, true)
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { bad_response }) do
+      assert_nil listmonk.create_campaigns(articles(:published_article), "Site")
+    end
+
+    listmonk.stub(:create_campaigns, 123) do
+      Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { bad_response }) do
+        assert_nil listmonk.send_newsletter(articles(:published_article), "Site")
+      end
+    end
+  end
+
+  test "fetch helpers return empty when http raises" do
+    listmonk = Listmonk.create!(
+      url: "https://listmonk.example.com",
+      username: "user",
+      api_key: "key",
+      list_id: 1,
+      template_id: 2
+    )
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs) { raise "boom" }) do
+      assert_equal [], listmonk.fetch_lists
+      assert_equal [], listmonk.fetch_templates
+    end
+  end
+
+  test "fetch_templates returns data on success" do
+    listmonk = Listmonk.create!(
+      url: "https://listmonk.example.com",
+      username: "user",
+      api_key: "key",
+      list_id: 1,
+      template_id: 2
+    )
+
+    response = Net::HTTPOK.new("1.1", "200", "OK")
+    response.body = { data: [ { "id" => 1 } ] }.to_json
+    response.instance_variable_set(:@read, true)
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &_block) { response }) do
+      assert_equal [ { "id" => 1 } ], listmonk.fetch_templates
+    end
+  end
+
+  test "uses http request blocks for listmonk calls" do
+    listmonk = Listmonk.create!(
+      url: "https://listmonk.example.com",
+      username: "user",
+      api_key: "key",
+      list_id: 1,
+      template_id: 2
+    )
+
+    lists_response = Net::HTTPOK.new("1.1", "200", "OK")
+    lists_response.body = { data: { results: [] } }.to_json
+    lists_response.instance_variable_set(:@read, true)
+    http = Struct.new(:response) { def request(_req) response end }.new(lists_response)
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+      assert_equal [], listmonk.fetch_lists
+    end
+
+    templates_response = Net::HTTPOK.new("1.1", "200", "OK")
+    templates_response.body = { data: [] }.to_json
+    templates_response.instance_variable_set(:@read, true)
+    http = Struct.new(:response) { def request(_req) response end }.new(templates_response)
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+      assert_equal [], listmonk.fetch_templates
+    end
+
+    create_response = Net::HTTPOK.new("1.1", "200", "OK")
+    create_response.body = { data: { id: 9 } }.to_json
+    create_response.instance_variable_set(:@read, true)
+    http = Struct.new(:response) { def request(_req) response end }.new(create_response)
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+      assert_equal 9, listmonk.create_campaigns(articles(:published_article), "Site")
+    end
+
+    send_response = Net::HTTPOK.new("1.1", "200", "OK")
+    send_response.body = "{}"
+    send_response.instance_variable_set(:@read, true)
+    http = Struct.new(:response) { def request(_req) response end }.new(send_response)
+    listmonk.stub(:create_campaigns, 9) do
+      Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+        assert_equal true, listmonk.send_newsletter(articles(:published_article), "Site")
+      end
+    end
+  end
+
+  test "fetch_lists handles non-success responses" do
+    listmonk = Listmonk.create!(
+      url: "https://listmonk.example.com",
+      username: "user",
+      api_key: "key",
+      list_id: 1,
+      template_id: 2
+    )
+
+    bad_response = Net::HTTPBadRequest.new("1.1", "400", "Bad")
+    bad_response.body = "{}"
+    bad_response.instance_variable_set(:@read, true)
+    http = Struct.new(:response) { def request(_req) response end }.new(bad_response)
+
+    Net::HTTP.stub(:start, ->(*_args, **_kwargs, &block) { block.call(http) }) do
+      assert_equal [], listmonk.fetch_lists
+    end
   end
 end

--- a/test/models/newsletter_setting_test.rb
+++ b/test/models/newsletter_setting_test.rb
@@ -1,0 +1,40 @@
+require "test_helper"
+
+class NewsletterSettingTest < ActiveSupport::TestCase
+  test "validates providers and reports configuration state" do
+    NewsletterSetting.delete_all
+    instance = NewsletterSetting.instance
+    assert instance.new_record?
+
+    invalid = NewsletterSetting.new(provider: "other")
+    assert_not invalid.valid?
+    assert_includes invalid.errors[:provider], "is not included in the list"
+
+    native_setting = NewsletterSetting.new(
+      provider: "native",
+      enabled: true,
+      smtp_address: "smtp.example.com",
+      smtp_port: 587,
+      smtp_user_name: "user",
+      smtp_password: "secret",
+      from_email: "from@example.com"
+    )
+    assert native_setting.native?
+    assert_not native_setting.listmonk?
+    assert native_setting.configured?
+    assert_equal [], native_setting.missing_config_fields
+
+    native_setting.smtp_password = nil
+    assert_not native_setting.configured?
+    assert_includes native_setting.missing_config_fields, "smtp_password"
+
+    listmonk_setting = NewsletterSetting.new(provider: "listmonk", enabled: true)
+    assert listmonk_setting.listmonk?
+    assert_not listmonk_setting.configured?
+    assert_equal [ "listmonk configuration" ], listmonk_setting.missing_config_fields
+
+    Listmonk.create!(api_key: "key", username: "user", url: "https://example.com")
+    assert listmonk_setting.configured?
+    assert_equal [], listmonk_setting.missing_config_fields
+  end
+end

--- a/test/models/page_test.rb
+++ b/test/models/page_test.rb
@@ -85,4 +85,15 @@ class PageTest < ActiveSupport::TestCase
     @page.redirect_url = ""
     assert @page.valid?
   end
+
+  test "rendered_content returns rich text content when rich_text" do
+    page = Page.create!(
+      title: "Rich Page",
+      slug: "rich-page",
+      status: :publish,
+      content: "<p>Rich content</p>"
+    )
+
+    assert_includes page.rendered_content.to_s, "Rich content"
+  end
 end

--- a/test/models/session_test.rb
+++ b/test/models/session_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class SessionTest < ActiveSupport::TestCase
+  test "requires a user association" do
+    session = Session.new(user: users(:admin))
+    assert session.valid?
+
+    session.user = nil
+    assert_not session.valid?
+    assert_includes session.errors[:user], "must exist"
+  end
+end

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class SettingTest < ActiveSupport::TestCase
+  test "parses social links JSON and reports setup completeness" do
+    setting = settings(:default)
+    assert_not Setting.setup_incomplete?
+
+    setting.social_links_json = { "twitter" => "https://example.com" }.to_json
+    assert setting.save
+    assert_equal({ "twitter" => "https://example.com" }, setting.reload.social_links)
+
+    setting.social_links_json = "{invalid"
+    assert_not setting.save
+    assert_match(/包含无效的 JSON 格式/, setting.errors[:social_links_json].join)
+
+    setting.social_links_json = nil
+    setting.update!(setup_completed: false)
+    assert Setting.setup_incomplete?
+  end
+end

--- a/test/models/social_media_post_test.rb
+++ b/test/models/social_media_post_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class SocialMediaPostTest < ActiveSupport::TestCase
+  test "validates platform presence and uniqueness per article" do
+    article = articles(:published_article)
+
+    post = SocialMediaPost.new(article: article, platform: "twitter", url: "https://example.com/post-1")
+    assert post.valid?
+
+    SocialMediaPost.create!(article: article, platform: "twitter", url: "https://example.com/post-2")
+    duplicate = SocialMediaPost.new(article: article, platform: "twitter", url: "https://example.com/post-3")
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:platform], "has already been taken"
+
+    missing_platform = SocialMediaPost.new(article: article, platform: nil, url: "https://example.com/post-4")
+    assert_not missing_platform.valid?
+    assert_includes missing_platform.errors[:platform], "can't be blank"
+  end
+end

--- a/test/models/static_file_test.rb
+++ b/test/models/static_file_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class StaticFileTest < ActiveSupport::TestCase
+  test "validates attachment and exposes file metadata helpers" do
+    assert_nil StaticFile.new.public_path
+
+    invalid = StaticFile.new(filename: "missing.txt")
+    assert_not invalid.valid?
+    assert_includes invalid.errors[:file], "must be attached"
+    assert_nil invalid.file_size
+    assert_nil invalid.file_size_human
+
+    static_file = StaticFile.new(filename: "sample.txt")
+    File.open(Rails.root.join("test/fixtures/files/sample.txt")) do |file|
+      static_file.file.attach(io: file, filename: "sample.txt", content_type: "text/plain")
+    end
+
+    assert static_file.valid?
+    assert_equal "/static/sample.txt", static_file.public_path
+    assert_equal 28, static_file.file_size
+    assert_equal "28 B", static_file.file_size_human
+    assert_equal "text/plain", static_file.content_type
+  end
+
+  test "file_size_human formats kilobytes and megabytes" do
+    kb_file = StaticFile.new(filename: "kb.txt")
+    kb_temp = Tempfile.new("kb")
+    kb_temp.write("a" * 2048)
+    kb_temp.rewind
+    kb_file.file.attach(io: kb_temp, filename: "kb.txt", content_type: "text/plain")
+    kb_file.save!
+    kb_temp.close
+    kb_temp.unlink
+    assert_match(/KB\z/, kb_file.file_size_human)
+
+    mb_file = StaticFile.new(filename: "mb.txt")
+    mb_temp = Tempfile.new("mb")
+    mb_temp.write("a" * (2 * 1024 * 1024))
+    mb_temp.rewind
+    mb_file.file.attach(io: mb_temp, filename: "mb.txt", content_type: "text/plain")
+    mb_file.save!
+    mb_temp.close
+    mb_temp.unlink
+    assert_match(/MB\z/, mb_file.file_size_human)
+  end
+end

--- a/test/models/subscriber_tag_test.rb
+++ b/test/models/subscriber_tag_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class SubscriberTagTest < ActiveSupport::TestCase
+  test "enforces unique subscriber/tag pair" do
+    subscriber = subscribers(:confirmed_subscriber)
+    tag = tags(:ruby)
+
+    SubscriberTag.create!(subscriber: subscriber, tag: tag)
+    duplicate = SubscriberTag.new(subscriber: subscriber, tag: tag)
+
+    assert_not duplicate.valid?
+    assert_includes duplicate.errors[:subscriber_id], "has already been taken"
+  end
+end


### PR DESCRIPTION
Adds model coverage for article helpers, crosspost/listmonk behavior, and import/export flows.
Includes attachment and newsletter edge cases plus supporting test utilities.
Tests not run (not requested).