### PR TITLE
Translate comment reply copy to English

### DIFF
--- a/app/mailers/comment_mailer.rb
+++ b/app/mailers/comment_mailer.rb
@@ -13,7 +13,7 @@ class CommentMailer < ApplicationMailer
     @commentable_url = site_url.present? ? "#{site_url}#{@commentable_path}" : @commentable_path
 
     mail to: @parent.author_email,
-      subject: "你收到一条新的回复 | New reply to your comment | #{@site_title}"
+      subject: "New reply to your comment | #{@site_title}"
   end
 
   private

--- a/app/views/comment_mailer/reply_notification.html.erb
+++ b/app/views/comment_mailer/reply_notification.html.erb
@@ -33,21 +33,21 @@
     </style>
   </head>
   <body>
-    <h2>你收到一条新的回复</h2>
-    <p class="meta">New reply to your comment</p>
+    <h2>New reply to your comment</h2>
+    <p class="meta">You have a new reply</p>
 
     <p>
-      <strong>回复者 / From:</strong>
+      <strong>From:</strong>
       <%= @reply.author_name.to_s %>
     </p>
 
-    <p><strong>回复内容 / Reply:</strong></p>
+    <p><strong>Reply:</strong></p>
     <div class="reply">
       <%= simple_format(h(@reply.content.to_s)) %>
     </div>
 
     <% if @parent&.content.present? %>
-      <p><strong>你的评论 / Your comment:</strong></p>
+      <p><strong>Your comment:</strong></p>
       <div class="reply">
         <%= simple_format(h(truncate(@parent.content.to_s, length: 120))) %>
       </div>
@@ -55,18 +55,18 @@
 
     <% if @commentable_title.present? %>
       <p>
-        <strong>文章/页面 / Post/Page:</strong>
+        <strong>Post/Page:</strong>
         <%= @commentable_title %>
       </p>
     <% end %>
 
     <% if @commentable_url.present? %>
       <p>
-        <a class="button" href="<%= @commentable_url %>">查看详情 / View details</a>
+        <a class="button" href="<%= @commentable_url %>">View details</a>
       </p>
       <p class="meta"><%= @commentable_url %></p>
     <% end %>
 
-    <p class="meta">此邮件由 <%= @site_title %> 自动发送。</p>
+    <p class="meta">This email was sent automatically by <%= @site_title %>.</p>
   </body>
 </html>

--- a/app/views/comment_mailer/reply_notification.text.erb
+++ b/app/views/comment_mailer/reply_notification.text.erb
@@ -1,25 +1,24 @@
-你收到一条新的回复
 New reply to your comment
 
-回复者 / From:
+From:
 <%= @reply.author_name.to_s %>
 
-回复内容 / Reply:
+Reply:
 <%= @reply.content.to_s %>
 
 <% if @parent&.content.present? %>
-你的评论 / Your comment:
+Your comment:
 <%= truncate(@parent.content.to_s, length: 120) %>
 
 <% end %>
 <% if @commentable_title.present? %>
-文章/页面 / Post/Page:
+Post/Page:
 <%= @commentable_title %>
 
 <% end %>
 <% if @commentable_url.present? %>
-查看详情 / View details:
+View details:
 <%= @commentable_url %>
 
 <% end %>
-此邮件由 <%= @site_title %> 自动发送。
+This email was sent automatically by <%= @site_title %>.

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -36,7 +36,7 @@
         <%= f.text_field :author_name, required: true, placeholder: "Name *", class: "comment-form-input", data: is_mobile ? {} : { action: "focus->math-captcha#show" } %>
       </div>
       <div class="comment-form-field">
-        <%= f.email_field :author_email, placeholder: "邮箱（可选，用于接收回复提醒）", class: "comment-form-input" %>
+        <%= f.email_field :author_email, placeholder: "Email (optional, for reply notifications)", class: "comment-form-input" %>
       </div>
     </div>
 
@@ -54,7 +54,7 @@
     <div data-math-captcha-target="container" style="margin-bottom: 0.75rem;">
       <div class="comment-form-captcha">
         <label for="<%= captcha_answer_id %>" style="font-size: 0.875rem; color: #333; white-space: nowrap;"><span data-math-captcha-target="question"><%= captcha[:question] %></span></label>
-        <%= text_field_tag "captcha[answer]", nil, id: captcha_answer_id, required: true, inputmode: "numeric", autocomplete: "off", placeholder: "答案", class: "comment-captcha-input", data: { math_captcha_target: "answer", action: "input->math-captcha#validate blur->math-captcha#validate" } %>
+        <%= text_field_tag "captcha[answer]", nil, id: captcha_answer_id, required: true, inputmode: "numeric", autocomplete: "off", placeholder: "Answer", class: "comment-captcha-input", data: { math_captcha_target: "answer", action: "input->math-captcha#validate blur->math-captcha#validate" } %>
       </div>
       <div data-math-captcha-target="message" style="margin-top: 0.25rem; font-size: 12px; display: none;"></div>
       <%= hidden_field_tag "captcha[a]", captcha[:a], data: { math_captcha_target: "a" } %>

--- a/test/mailers/comment_mailer_test.rb
+++ b/test/mailers/comment_mailer_test.rb
@@ -1,7 +1,7 @@
 require "test_helper"
 
 class CommentMailerTest < ActionMailer::TestCase
-  test "reply notification email includes bilingual content and link" do
+  test "reply notification email includes english content and link" do
     article = articles(:published_article)
     parent = Comment.create!(
       commentable: article,
@@ -20,7 +20,7 @@ class CommentMailerTest < ActionMailer::TestCase
     email = CommentMailer.reply_notification(reply, CacheableSettings.site_info)
 
     assert_equal [ "parent@example.com" ], email.to
-    assert_includes email.subject, "你收到一条新的回复"
+    assert_includes email.subject, "New reply to your comment"
     assert_includes email.subject, "Test Site"
     assert email.text_part
     assert email.html_part
@@ -28,7 +28,7 @@ class CommentMailerTest < ActionMailer::TestCase
     text_body = email.text_part.body.to_s
     html_body = email.html_part.body.to_s
 
-    assert_includes text_body, "回复内容"
+    assert_includes text_body, "Reply:"
     assert_includes text_body, "Reply content"
     assert_includes text_body, article.title
 


### PR DESCRIPTION
Updates comment reply notification subject/body and comment form placeholders to English. Adjusts mailer test assertions accordingly.