### PR TITLE
Add admin settings tabs and preserve active selection

### DIFF
--- a/app/assets/stylesheets/admin.css
+++ b/app/assets/stylesheets/admin.css
@@ -635,57 +635,88 @@ table tbody tr:hover {
     margin: 0.5rem 0 0;
 }
 
-/* Activity table: minimal, dense, no-wrap */
+/* Activity table: compact, wrap to show full content */
 .admin-activity-table {
     table-layout: fixed;
+    width: 100%;
+}
+
+.admin-activity-table thead th {
+    padding: 0.45rem 0.6rem;
+    font-size: 12px;
+}
+
+.admin-activity-table tbody td {
+    padding: 0.45rem 0.6rem;
+    font-size: 13px;
+    line-height: 1.3;
+}
+
+.admin-activity-table .col-time,
+.admin-activity-table .col-level,
+.admin-activity-table .col-action,
+.admin-activity-table .col-target {
+    padding-left: 0.4rem;
+    padding-right: 0.4rem;
 }
 
 .admin-activity-table th,
 .admin-activity-table td {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    vertical-align: middle;
+    vertical-align: top;
+}
+
+.admin-activity-table td {
+    white-space: normal;
+    overflow: visible;
+    text-overflow: clip;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 .admin-activity-table .truncate {
     display: block;
     min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    overflow: visible;
+    text-overflow: clip;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    word-break: break-word;
 }
 
 /* Column widths (information-dense defaults) */
 .admin-activity-table .col-time {
-    width: 170px;
+    width: 140px;
 }
 
 .admin-activity-table .col-level {
-    width: 78px;
+    width: 72px;
 }
 
 .admin-activity-table .col-action {
-    width: 160px;
+    width: 120px;
 }
 
 .admin-activity-table .col-target {
-    width: 220px;
+    width: 170px;
 }
 
 /* Description cell can contain text + action button */
 .admin-activity-table .col-description {
+    width: auto;
+}
+
+.admin-activity-table .col-description .description-content {
     display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    align-items: flex-start;
+    gap: 0.35rem;
     min-width: 0;
 }
 
-.admin-activity-table .col-description .truncate {
+.admin-activity-table .col-description .description-content .truncate {
     flex: 1;
 }
 
-.admin-activity-table .col-description .btn {
+.admin-activity-table .col-description .description-content .btn {
     flex: 0 0 auto;
 }
 

--- a/app/controllers/admin/crossposts_controller.rb
+++ b/app/controllers/admin/crossposts_controller.rb
@@ -4,6 +4,7 @@ class Admin::CrosspostsController < Admin::BaseController
     @twitter = Crosspost.twitter
     @bluesky = Crosspost.bluesky
     @xiaohongshu = Crosspost.xiaohongshu
+    @active_platform = Crosspost::PLATFORMS.include?(params[:platform]) ? params[:platform] : "mastodon"
   end
 
   def update
@@ -19,7 +20,7 @@ class Admin::CrosspostsController < Admin::BaseController
         description: "更新跨平台发布设置: #{params[:id]}"
       )
       # Rails.logger.info "Successfully updated Crosspost"
-      redirect_to admin_crossposts_path, notice: "CrossPost settings updated successfully."
+      redirect_to admin_crossposts_path(platform: params[:id]), notice: "CrossPost settings updated successfully."
     else
       ActivityLog.create!(
         action: "failed",
@@ -28,7 +29,7 @@ class Admin::CrosspostsController < Admin::BaseController
         description: "更新跨平台发布设置失败: #{params[:id]} - #{@settings.errors.full_messages.join(', ')}"
       )
       # Rails.logger.error "Failed to update Crosspost: #{@settings.errors.full_messages}"
-      redirect_to admin_crossposts_path, alert: @settings.errors.full_messages.join(", ")
+      redirect_to admin_crossposts_path(platform: params[:id]), alert: @settings.errors.full_messages.join(", ")
     end
   end
 

--- a/app/controllers/admin/git_integrations_controller.rb
+++ b/app/controllers/admin/git_integrations_controller.rb
@@ -2,6 +2,7 @@ class Admin::GitIntegrationsController < Admin::BaseController
   def index
     GitIntegration.ensure_all_providers
     @integrations = GitIntegration.order(:provider)
+    @active_provider = GitIntegration::PROVIDERS.include?(params[:provider]) ? params[:provider] : "github"
   end
 
   def update
@@ -21,7 +22,7 @@ class Admin::GitIntegrationsController < Admin::BaseController
         level: :info,
         description: "更新 Git 集成设置: #{@integration.display_name}"
       )
-      redirect_to admin_git_integrations_path, notice: "#{@integration.display_name} 设置已更新。"
+      redirect_to admin_git_integrations_path(provider: provider), notice: "#{@integration.display_name} 设置已更新。"
     else
       ActivityLog.create!(
         action: "failed",
@@ -29,7 +30,7 @@ class Admin::GitIntegrationsController < Admin::BaseController
         level: :error,
         description: "更新 Git 集成设置失败: #{@integration.display_name} - #{@integration.errors.full_messages.join(', ')}"
       )
-      redirect_to admin_git_integrations_path, alert: @integration.errors.full_messages.join(", ")
+      redirect_to admin_git_integrations_path(provider: provider), alert: @integration.errors.full_messages.join(", ")
     end
   end
 

--- a/app/controllers/admin/newsletter_controller.rb
+++ b/app/controllers/admin/newsletter_controller.rb
@@ -2,6 +2,7 @@ class Admin::NewsletterController < Admin::BaseController
   def show
     @newsletter_setting = NewsletterSetting.instance
     @listmonk = Listmonk.first_or_initialize
+    @active_tab = newsletter_tab(params[:tab])
 
     load_listmonk_options
   end
@@ -166,6 +167,7 @@ class Admin::NewsletterController < Admin::BaseController
   def update
     @newsletter_setting = NewsletterSetting.instance
     @listmonk = Listmonk.first_or_initialize
+    @active_tab = newsletter_tab(params[:tab])
 
     # Update newsletter setting (native email)
     if params[:newsletter_setting].present?
@@ -179,7 +181,7 @@ class Admin::NewsletterController < Admin::BaseController
       if @newsletter_setting.update(setting_params)
         # Configure ActionMailer for SMTP if native is enabled
         configure_action_mailer if @newsletter_setting.enabled? && @newsletter_setting.native?
-        redirect_to admin_newsletter_path, notice: "Newsletter settings updated successfully."
+        redirect_to admin_newsletter_path(tab: @active_tab), notice: "Newsletter settings updated successfully."
         return
       else
         load_listmonk_options
@@ -191,7 +193,7 @@ class Admin::NewsletterController < Admin::BaseController
 
     # Update listmonk settings
     if @listmonk.update(listmonk_params)
-      redirect_to admin_newsletter_path, notice: "Newsletter settings updated successfully."
+      redirect_to admin_newsletter_path(tab: @active_tab), notice: "Newsletter settings updated successfully."
     else
       load_listmonk_options
       flash.now[:alert] = @listmonk.errors.full_messages.join(", ")
@@ -245,5 +247,9 @@ class Admin::NewsletterController < Admin::BaseController
 
     @lists = @listmonk.fetch_lists || []
     @templates = @listmonk.fetch_templates || []
+  end
+
+  def newsletter_tab(value)
+    %w[general native listmonk].include?(value) ? value : "general"
   end
 end

--- a/app/javascript/controllers/newsletter_controller.js
+++ b/app/javascript/controllers/newsletter_controller.js
@@ -2,7 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["providerSelect", "nativeSettings", "listmonkSettings", "verifyBtn", "verifyStatus", "listSelect", "templateSelect", "sesVerifyBtn", "sesVerifyStatus"]
-  static values = { verifyUrl: String }
+  static values = { verifyUrl: String, activeTab: String }
 
   connect() {
     this.updateSettingsVisibility()
@@ -130,14 +130,24 @@ export default class extends Controller {
   }
 
   updateSettingsVisibility() {
+    if (this.hasActiveTabValue && this.activeTabValue) {
+      if (this.hasNativeSettingsTarget) {
+        this.nativeSettingsTarget.style.display = this.activeTabValue === 'native' ? 'block' : 'none'
+      }
+      if (this.hasListmonkSettingsTarget) {
+        this.listmonkSettingsTarget.style.display = this.activeTabValue === 'listmonk' ? 'block' : 'none'
+      }
+      return
+    }
+
+    if (!this.hasProviderSelectTarget) return
     const provider = this.providerSelectTarget.value
-    
-    if (provider === 'native') {
-      this.nativeSettingsTarget.style.display = 'block'
-      this.listmonkSettingsTarget.style.display = 'none'
-    } else {
-      this.nativeSettingsTarget.style.display = 'none'
-      this.listmonkSettingsTarget.style.display = 'block'
+
+    if (this.hasNativeSettingsTarget) {
+      this.nativeSettingsTarget.style.display = provider === 'native' ? 'block' : 'none'
+    }
+    if (this.hasListmonkSettingsTarget) {
+      this.listmonkSettingsTarget.style.display = provider === 'native' ? 'none' : 'block'
     }
   }
 }

--- a/app/views/admin/activities/index.html.erb
+++ b/app/views/admin/activities/index.html.erb
@@ -4,11 +4,11 @@
     <table class="admin-activity-table">
       <thead>
         <tr>
-          <th>Time</th>
-          <th>Level</th>
-          <th>Action</th>
-          <th>Target</th>
-          <th>Description</th>
+          <th class="col-time">Time</th>
+          <th class="col-level">Level</th>
+          <th class="col-action">Action</th>
+          <th class="col-target">Target</th>
+          <th class="col-description">Description</th>
         </tr>
       </thead>
       <tbody>
@@ -30,17 +30,18 @@
               <code class="truncate" title="<%= target_text.squish %>"><%= target_text %></code>
             </td>
             <td class="col-description">
-              <% description_text = log.description.to_s %>
-              <% if description_text.include?('/tmp/exports/') %>
-                <% filename = description_text.split('/').last %>
-                <% prefix = description_text.split(':').first.to_s %>
-                <span class="truncate" title="<%= description_text.squish %>"><%= prefix %></span>
-                <% if filename.present? %>
-                  <%= link_to "Download", admin_download_path(filename), class: "btn btn-small", download: filename %>
+              <div class="description-content">
+                <% description_text = log.description.to_s %>
+                <% if description_text.include?('/tmp/exports/') %>
+                  <% filename = description_text.split('/').last %>
+                  <span class="truncate" title="<%= description_text.squish %>"><%= description_text %></span>
+                  <% if filename.present? %>
+                    <%= link_to "Download", admin_download_path(filename), class: "btn btn-small", download: filename %>
+                  <% end %>
+                <% else %>
+                  <span class="truncate" title="<%= description_text.squish %>"><%= description_text %></span>
                 <% end %>
-              <% else %>
-                <span class="truncate" title="<%= description_text.squish %>"><%= description_text %></span>
-              <% end %>
+              </div>
             </td>
           </tr>
         <% end %>

--- a/app/views/admin/crossposts/index.html.erb
+++ b/app/views/admin/crossposts/index.html.erb
@@ -1,6 +1,21 @@
 <div class="admin-container">
   <h1>Crosspost Settings</h1>
 
+  <div class="admin-toolbar">
+    <div class="status-tabs">
+      <% platform_tabs = {
+        "mastodon" => "Mastodon",
+        "twitter" => "X (Twitter)",
+        "bluesky" => "Bluesky",
+        "xiaohongshu" => "Xiaohongshu"
+      } %>
+      <% platform_tabs.each do |platform, label| %>
+        <%= link_to label, admin_crossposts_path(platform: platform), class: "status-tab #{@active_platform == platform ? 'active' : ''}" %>
+      <% end %>
+    </div>
+  </div>
+
+  <% if @active_platform == "mastodon" %>
   <div class="form-section compact">
     <h3>Mastodon</h3>
     <small>Get credentials: Open Mastodon → Preferences → Development → New application | Scope: profile,write:statuses</small>
@@ -82,7 +97,9 @@
     <% end %>
     <div id="verify-messages-mastodon"></div>
   </div>
+  <% end %>
 
+  <% if @active_platform == "twitter" %>
   <div class="form-section compact">
     <h3>X (Twitter)</h3>
     <small>First, obtain X credentials from <%= link_to "https://developer.x.com", "https://developer.x.com", target: "_blank" %></small>
@@ -144,7 +161,9 @@
     <% end %>
     <div id="verify-messages-twitter"></div>
   </div>
+  <% end %>
 
+  <% if @active_platform == "bluesky" %>
   <div class="form-section compact">
     <h3>Bluesky</h3>
     <small>Get credentials: Log in to your Bluesky account and generate an App Password in settings.</small>
@@ -218,7 +237,9 @@
     <% end %>
     <div id="verify-messages-bluesky"></div>
   </div>
+  <% end %>
 
+  <% if @active_platform == "xiaohongshu" %>
   <div class="form-section compact">
     <h3>Xiaohongshu</h3>
     <small>No public API available. These fields are for reference and manual posting.</small>
@@ -256,6 +277,7 @@
       </div>
     <% end %>
   </div>
+  <% end %>
 
 </div>
 

--- a/app/views/admin/git_integrations/index.html.erb
+++ b/app/views/admin/git_integrations/index.html.erb
@@ -4,7 +4,16 @@
   <h1>Git Integrations</h1>
   <p class="text-muted">配置 Git 提供商的认证信息，用于静态文件部署。</p>
 
+  <div class="admin-toolbar">
+    <div class="status-tabs">
+      <% @integrations.each do |integration| %>
+        <%= link_to integration.display_name, admin_git_integrations_path(provider: integration.provider), class: "status-tab #{@active_provider == integration.provider ? 'active' : ''}" %>
+      <% end %>
+    </div>
+  </div>
+
   <% @integrations.each do |integration| %>
+    <% next unless integration.provider == @active_provider %>
     <div class="form-section compact">
       <h2><%= integration.display_name %></h2>
       <small><%= provider_help_text(integration.provider) %></small>

--- a/app/views/admin/migrates/index.html.erb
+++ b/app/views/admin/migrates/index.html.erb
@@ -1,6 +1,14 @@
 <div class="admin-container">
   <h1>Migrate</h1>
+
+  <div class="admin-toolbar">
+    <div class="status-tabs">
+      <%= link_to "Export", admin_migrates_path(tab: "export"), class: "status-tab #{@active_tab == 'export' ? 'active' : ''}" %>
+      <%= link_to "Import", admin_migrates_path(tab: "import"), class: "status-tab #{@active_tab == 'import' ? 'active' : ''}" %>
+    </div>
+  </div>
   
+  <% if @active_tab == "export" %>
   <div class="form-section compact">
     <h3>Export Data</h3>
     
@@ -26,7 +34,9 @@
       </div>
     </div>
   </div>
+  <% end %>
 
+  <% if @active_tab == "import" %>
   <div class="form-section compact">
     <h3>Import Data</h3>
     
@@ -68,5 +78,6 @@
       </div>
     </div>
   </div>
+  <% end %>
 
 </div>

--- a/app/views/admin/newsletter/show.html.erb
+++ b/app/views/admin/newsletter/show.html.erb
@@ -1,117 +1,138 @@
 <h3>Newsletter Settings</h3>
 
-<div data-controller="newsletter" data-newsletter-verify-url-value="<%= verify_admin_newsletter_path %>">
-  <div class="form-section">
-    <%= form_with(model: @newsletter_setting, url: admin_newsletter_path, method: :patch) do |form| %>
-      <div class="field">
-        <%= form.label :enabled, "Enable Newsletter" %>
-        <%= form.check_box :enabled %>
-      </div>
-      <h4>Select Email Service Provider</h4>
-      <div class="field">
-        <%= form.label :provider, "Provider" %>
-        <%= form.select :provider, [["Native Email", "native"], ["Listmonk", "listmonk"]], { selected: @newsletter_setting.provider || "native" }, { data: { newsletter_target: "providerSelect", action: "change->newsletter#providerChanged" } } %>
-      </div>
+<div data-controller="newsletter" data-newsletter-verify-url-value="<%= verify_admin_newsletter_path %>" data-newsletter-active-tab-value="<%= @active_tab %>">
+  <div class="admin-toolbar">
+    <div class="status-tabs">
+      <%= link_to "General", admin_newsletter_path(tab: "general"), class: "status-tab #{@active_tab == 'general' ? 'active' : ''}" %>
+      <%= link_to "Native Email", admin_newsletter_path(tab: "native"), class: "status-tab #{@active_tab == 'native' ? 'active' : ''}" %>
+      <%= link_to "Listmonk", admin_newsletter_path(tab: "listmonk"), class: "status-tab #{@active_tab == 'listmonk' ? 'active' : ''}" %>
+    </div>
+  </div>
 
-      <div id="native-email-settings" data-newsletter-target="nativeSettings" style="display: <%= @newsletter_setting.native? ? 'block' : 'none' %>">
-        <h4>SMTP Configuration</h4>
-        
+  <% if @active_tab == "general" %>
+    <div class="form-section">
+      <%= form_with(model: @newsletter_setting, url: admin_newsletter_path, method: :patch) do |form| %>
+        <%= hidden_field_tag :tab, "general" %>
         <div class="field">
-          <%= form.label :smtp_address, "SMTP Address" %>
-          <%= form.text_field :smtp_address, placeholder: "smtp.example.com" %>
+          <%= form.label :enabled, "Enable Newsletter" %>
+          <%= form.check_box :enabled %>
+        </div>
+        <h4>Select Email Service Provider</h4>
+        <div class="field">
+          <%= form.label :provider, "Provider" %>
+          <%= form.select :provider, [["Native Email", "native"], ["Listmonk", "listmonk"]], { selected: @newsletter_setting.provider || "native" }, { data: { newsletter_target: "providerSelect", action: "change->newsletter#providerChanged" } } %>
         </div>
 
-        <div class="field">
-          <%= form.label :smtp_port, "SMTP Port" %>
-          <%= form.number_field :smtp_port, placeholder: "587", value: @newsletter_setting.smtp_port || 587 %>
+        <div><%= form.submit "Save General Settings" %></div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if @active_tab == "native" %>
+    <div class="form-section">
+      <%= form_with(model: @newsletter_setting, url: admin_newsletter_path, method: :patch) do |form| %>
+        <%= hidden_field_tag :tab, "native" %>
+        <div id="native-email-settings" data-newsletter-target="nativeSettings">
+          <h4>SMTP Configuration</h4>
+          
+          <div class="field">
+            <%= form.label :smtp_address, "SMTP Address" %>
+            <%= form.text_field :smtp_address, placeholder: "smtp.example.com" %>
+          </div>
+
+          <div class="field">
+            <%= form.label :smtp_port, "SMTP Port" %>
+            <%= form.number_field :smtp_port, placeholder: "587", value: @newsletter_setting.smtp_port || 587 %>
+          </div>
+
+          <div class="field">
+            <%= form.label :smtp_user_name, "SMTP Username" %>
+            <%= form.text_field :smtp_user_name %>
+          </div>
+
+          <div class="field">
+            <%= form.label :smtp_password, "SMTP Password" %>
+            <%= form.password_field :smtp_password, value: @newsletter_setting.smtp_password.present? ? "••••••••" : nil, placeholder: "Enter password" %>
+          </div>
+
+          <div class="field">
+            <%= form.label :smtp_domain, "SMTP Domain (optional)" %>
+            <%= form.text_field :smtp_domain, placeholder: "example.com" %>
+            <small>Leave blank to auto-detect from From Email</small>
+          </div>
+
+          <div class="field">
+            <%= form.label :smtp_authentication, "Authentication" %>
+            <%= form.select :smtp_authentication, [["Plain", "plain"], ["Login", "login"], ["CRAM-MD5", "cram_md5"]], { selected: @newsletter_setting.smtp_authentication || "plain" } %>
+          </div>
+
+          <div class="field">
+            <%= form.label :smtp_enable_starttls, "Enable STARTTLS" %>
+            <%= form.check_box :smtp_enable_starttls, checked: @newsletter_setting.smtp_enable_starttls.nil? ? true : @newsletter_setting.smtp_enable_starttls %>
+          </div>
+
+          <div class="field">
+            <%= form.label :from_email, "From Email" %>
+            <%= form.email_field :from_email, placeholder: "noreply@example.com" %>
+          </div>
+
+          <div style="margin: 15px 0;">
+            <button type="button" data-newsletter-target="sesVerifyBtn" data-action="click->newsletter#verifySes" class="btn btn-secondary">Verify SMTP Configuration</button>
+            <span data-newsletter-target="sesVerifyStatus" style="margin-left: 10px;"></span>
+          </div>
+
+          <div class="field">
+            <%= form.label :footer, "Email Footer (Rich Text)" %>
+            <%= form.rich_text_area :footer %>
+          </div>
+
+          <div style="margin-top: 20px;">
+            <%= link_to "Manage Subscribers", admin_subscribers_path, class: "btn btn-secondary" %>
+          </div>
+          <div><%= form.submit "Save Native Email Settings" %></div>
+        </div>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if @active_tab == "listmonk" %>
+    <div class="form-section" id="listmonk-settings" data-newsletter-target="listmonkSettings">
+      <h4>Listmonk Configuration</h4>
+      <%= form_with(model: @listmonk, url: admin_newsletter_path, method: :patch) do |form| %>
+        <%= hidden_field_tag :tab, "listmonk" %>
+        <div>
+          <%= form.label :url, "Listmonk URL" %>
+          <%= form.text_field :url, placeholder: "https://example.com" %>
         </div>
 
-        <div class="field">
-          <%= form.label :smtp_user_name, "SMTP Username" %>
-          <%= form.text_field :smtp_user_name %>
+        <div>
+          <%= form.label :username, "Username" %>
+          <%= form.text_field :username %>
         </div>
 
-        <div class="field">
-          <%= form.label :smtp_password, "SMTP Password" %>
-          <%= form.password_field :smtp_password, value: @newsletter_setting.smtp_password.present? ? "••••••••" : nil, placeholder: "Enter password" %>
-        </div>
-
-        <div class="field">
-          <%= form.label :smtp_domain, "SMTP Domain (optional)" %>
-          <%= form.text_field :smtp_domain, placeholder: "example.com" %>
-          <small>Leave blank to auto-detect from From Email</small>
-        </div>
-
-        <div class="field">
-          <%= form.label :smtp_authentication, "Authentication" %>
-          <%= form.select :smtp_authentication, [["Plain", "plain"], ["Login", "login"], ["CRAM-MD5", "cram_md5"]], { selected: @newsletter_setting.smtp_authentication || "plain" } %>
-        </div>
-
-        <div class="field">
-          <%= form.label :smtp_enable_starttls, "Enable STARTTLS" %>
-          <%= form.check_box :smtp_enable_starttls, checked: @newsletter_setting.smtp_enable_starttls.nil? ? true : @newsletter_setting.smtp_enable_starttls %>
-        </div>
-
-        <div class="field">
-          <%= form.label :from_email, "From Email" %>
-          <%= form.email_field :from_email, placeholder: "noreply@example.com" %>
+        <div>
+          <%= form.label :api_key, "API Key" %>
+          <%= form.text_field :api_key %>
         </div>
 
         <div style="margin: 15px 0;">
-          <button type="button" data-newsletter-target="sesVerifyBtn" data-action="click->newsletter#verifySes" class="btn btn-secondary">Verify SMTP Configuration</button>
-          <span data-newsletter-target="sesVerifyStatus" style="margin-left: 10px;"></span>
+          <button type="button" data-newsletter-target="verifyBtn" data-action="click->newsletter#verify" class="btn btn-secondary">Verify Configuration</button>
+          <span data-newsletter-target="verifyStatus" style="margin-left: 10px;"></span>
         </div>
 
-        <div class="field">
-          <%= form.label :footer, "Email Footer (Rich Text)" %>
-          <%= form.rich_text_area :footer %>
+        <div id="list-template-container">
+          <div>
+            <%= form.label :list_id, "List" %>
+            <%= form.select :list_id, options_for_select(Array(@lists).map { |l| [l["name"], l["id"]] }, @listmonk.list_id), { include_blank: "Select a List" }, { id: "list-select", data: { newsletter_target: "listSelect" } } %>
+          </div>
+          <div>
+            <%= form.label :template_id, "Template" %>
+            <%= form.select :template_id, options_for_select(Array(@templates).map { |l| [l["name"], l["id"]] }, @listmonk.template_id), { include_blank: "Select a Template" }, { id: "template-select", data: { newsletter_target: "templateSelect" } } %>
+          </div>
         </div>
 
-        <div style="margin-top: 20px;">
-          <%= link_to "Manage Subscribers", admin_subscribers_path, class: "btn btn-secondary" %>
-        </div>
-        <div><%= form.submit "Save Native Email Settings" %></div>
-
-      </div>
-
-    <% end %>
-  </div>
-
-  <div class="form-section" id="listmonk-settings" data-newsletter-target="listmonkSettings" style="display: <%= @newsletter_setting.listmonk? ? 'block' : 'none' %>">
-  <h4>Listmonk Configuration</h4>
-  <%= form_with(model: @listmonk, url: admin_newsletter_path, method: :patch) do |form| %>
-    <div>
-      <%= form.label :url, "Listmonk URL" %>
-      <%= form.text_field :url, placeholder: "https://example.com" %>
+        <div><%= form.submit "Save Listmonk Settings" %></div>
+      <% end %>
     </div>
-
-    <div>
-      <%= form.label :username, "Username" %>
-      <%= form.text_field :username %>
-    </div>
-
-    <div>
-      <%= form.label :api_key, "API Key" %>
-      <%= form.text_field :api_key %>
-    </div>
-
-    <div style="margin: 15px 0;">
-      <button type="button" data-newsletter-target="verifyBtn" data-action="click->newsletter#verify" class="btn btn-secondary">Verify Configuration</button>
-      <span data-newsletter-target="verifyStatus" style="margin-left: 10px;"></span>
-    </div>
-
-    <div id="list-template-container">
-      <div>
-        <%= form.label :list_id, "List" %>
-        <%= form.select :list_id, options_for_select(Array(@lists).map { |l| [l["name"], l["id"]] }, @listmonk.list_id), { include_blank: "Select a List" }, { id: "list-select", data: { newsletter_target: "listSelect" } } %>
-      </div>
-      <div>
-        <%= form.label :template_id, "Template" %>
-        <%= form.select :template_id, options_for_select(Array(@templates).map { |l| [l["name"], l["id"]] }, @listmonk.template_id), { include_blank: "Select a Template" }, { id: "template-select", data: { newsletter_target: "templateSelect" } } %>
-      </div>
-    </div>
-
-    <div><%= form.submit "Save Listmonk Settings" %></div>
   <% end %>
-  </div>
 </div>

--- a/test/controllers/admin/crossposts_controller_test.rb
+++ b/test/controllers/admin/crossposts_controller_test.rb
@@ -9,6 +9,11 @@ class Admin::CrosspostsControllerTest < ActionDispatch::IntegrationTest
   test "index update and verify flows" do
     get admin_crossposts_path
     assert_response :success
+    assert_select ".status-tab.active", text: "Mastodon"
+
+    get admin_crossposts_path(platform: "twitter")
+    assert_response :success
+    assert_select ".status-tab.active", text: "X (Twitter)"
 
     patch admin_crosspost_path("mastodon"), params: {
       crosspost: {
@@ -17,7 +22,7 @@ class Admin::CrosspostsControllerTest < ActionDispatch::IntegrationTest
         server_url: "https://mastodon.example"
       }
     }
-    assert_redirected_to admin_crossposts_path
+    assert_redirected_to admin_crossposts_path(platform: "mastodon")
 
     patch admin_crosspost_path("mastodon"), params: {
       crosspost: {
@@ -26,7 +31,7 @@ class Admin::CrosspostsControllerTest < ActionDispatch::IntegrationTest
         server_url: "https://mastodon.example"
       }
     }
-    assert_redirected_to admin_crossposts_path
+    assert_redirected_to admin_crossposts_path(platform: "mastodon")
 
     with_stubbed_verify(MastodonService, { success: true }) do
       post verify_admin_crosspost_path("mastodon"), params: {

--- a/test/controllers/admin/git_integrations_controller_test.rb
+++ b/test/controllers/admin/git_integrations_controller_test.rb
@@ -10,6 +10,11 @@ class Admin::GitIntegrationsControllerTest < ActionDispatch::IntegrationTest
   test "index update verify and helpers" do
     get admin_git_integrations_path
     assert_response :success
+    assert_select ".status-tab.active", text: "GitHub"
+
+    get admin_git_integrations_path(provider: "gitlab")
+    assert_response :success
+    assert_select ".status-tab.active", text: "GitLab"
 
     patch admin_git_integration_path("unknown"), params: {
       git_integration: { enabled: "1" }
@@ -23,7 +28,7 @@ class Admin::GitIntegrationsControllerTest < ActionDispatch::IntegrationTest
         server_url: ""
       }
     }
-    assert_redirected_to admin_git_integrations_path
+    assert_redirected_to admin_git_integrations_path(provider: "github")
 
     patch admin_git_integration_path("github"), params: {
       git_integration: {
@@ -31,7 +36,7 @@ class Admin::GitIntegrationsControllerTest < ActionDispatch::IntegrationTest
         access_token: ""
       }
     }
-    assert_redirected_to admin_git_integrations_path
+    assert_redirected_to admin_git_integrations_path(provider: "github")
 
     post verify_admin_git_integration_path("github"), params: {
       git_integration: { access_token: "" }

--- a/test/controllers/admin/migrates_controller_test.rb
+++ b/test/controllers/admin/migrates_controller_test.rb
@@ -20,6 +20,11 @@ class Admin::MigratesControllerTest < ActionDispatch::IntegrationTest
     sign_in(@user)
     get admin_migrates_path
     assert_response :success
+    assert_select ".status-tab.active", text: "Export"
+
+    get admin_migrates_path(tab: "import")
+    assert_response :success
+    assert_select ".status-tab.active", text: "Import"
   end
 
   test "should require authentication for create" do
@@ -34,7 +39,7 @@ class Admin::MigratesControllerTest < ActionDispatch::IntegrationTest
       post admin_migrates_path, params: { operation_type: "export", export_type: "default" }
     end
 
-    assert_redirected_to admin_migrates_path
+    assert_redirected_to admin_migrates_path(tab: "export")
     assert_match "Export Initiated", flash[:notice]
   end
 
@@ -45,7 +50,7 @@ class Admin::MigratesControllerTest < ActionDispatch::IntegrationTest
       post admin_migrates_path, params: { operation_type: "export", export_type: "markdown" }
     end
 
-    assert_redirected_to admin_migrates_path
+    assert_redirected_to admin_migrates_path(tab: "export")
     assert_match "Markdown Export Initiated", flash[:notice]
   end
 
@@ -63,7 +68,7 @@ class Admin::MigratesControllerTest < ActionDispatch::IntegrationTest
       zip_file: file
     }
 
-    assert_redirected_to admin_migrates_path
+    assert_redirected_to admin_migrates_path(tab: "import")
     assert_match "ZIP", flash[:alert]
   end
 
@@ -82,7 +87,7 @@ class Admin::MigratesControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
-    assert_redirected_to admin_migrates_path
+    assert_redirected_to admin_migrates_path(tab: "import")
     assert_match "ZIP Import in progress", flash[:notice]
   end
 
@@ -105,7 +110,7 @@ class Admin::MigratesControllerTest < ActionDispatch::IntegrationTest
       }
     end
 
-    assert_redirected_to admin_migrates_path
+    assert_redirected_to admin_migrates_path(tab: "import")
     assert_match "RSS Import in progress", flash[:notice]
   end
 
@@ -114,7 +119,7 @@ class Admin::MigratesControllerTest < ActionDispatch::IntegrationTest
 
     post admin_migrates_path, params: { operation_type: "invalid" }
 
-    assert_redirected_to admin_migrates_path
+    assert_redirected_to admin_migrates_path(tab: "export")
     assert_match "Unsupported operation type", flash[:alert]
   end
 

--- a/test/controllers/admin/newsletter_controller_test.rb
+++ b/test/controllers/admin/newsletter_controller_test.rb
@@ -8,6 +8,7 @@ class Admin::NewsletterControllerTest < ActionDispatch::IntegrationTest
 
   test "update accepts submit param and redirects" do
     patch admin_newsletter_path, params: {
+      tab: "native",
       newsletter_setting: {
         enabled: "1",
         provider: "native",
@@ -24,12 +25,13 @@ class Admin::NewsletterControllerTest < ActionDispatch::IntegrationTest
       }
     }
 
-    assert_redirected_to admin_newsletter_path
+    assert_redirected_to admin_newsletter_path(tab: "native")
     assert_equal "smtp.example.com", NewsletterSetting.first.smtp_address
   end
 
   test "update renders show on validation failure without error" do
     patch admin_newsletter_path, params: {
+      tab: "native",
       newsletter_setting: {
         enabled: "1",
         provider: "native",
@@ -52,6 +54,7 @@ class Admin::NewsletterControllerTest < ActionDispatch::IntegrationTest
 
   test "listmonk update failure renders show without error" do
     patch admin_newsletter_path, params: {
+      tab: "listmonk",
       listmonk: {
         url: "not-a-url",
         username: "",
@@ -68,6 +71,11 @@ class Admin::NewsletterControllerTest < ActionDispatch::IntegrationTest
   test "verify listmonk responses and update listmonk settings" do
     get admin_newsletter_path
     assert_response :success
+    assert_select ".status-tab.active", text: "General"
+
+    get admin_newsletter_path(tab: "listmonk")
+    assert_response :success
+    assert_select ".status-tab.active", text: "Listmonk"
 
     post verify_admin_newsletter_path, params: { username: "", api_key: "", url: "" }, as: :json
     assert_response :unprocessable_entity
@@ -103,6 +111,7 @@ class Admin::NewsletterControllerTest < ActionDispatch::IntegrationTest
     end
 
     patch admin_newsletter_path, params: {
+      tab: "listmonk",
       listmonk: {
         enabled: "1",
         url: "https://listmonk.example",
@@ -112,7 +121,7 @@ class Admin::NewsletterControllerTest < ActionDispatch::IntegrationTest
         template_id: 2
       }
     }
-    assert_redirected_to admin_newsletter_path
+    assert_redirected_to admin_newsletter_path(tab: "listmonk")
   end
 
   test "verify smtp handles validation and authentication errors" do

--- a/test/system/admin_newsletter_tabs_test.rb
+++ b/test/system/admin_newsletter_tabs_test.rb
@@ -1,0 +1,27 @@
+require "application_system_test_case"
+
+class AdminNewsletterTabsTest < ApplicationSystemTestCase
+  def setup
+    @user = users(:admin)
+  end
+
+  test "newsletter settings tabs show the right sections" do
+    sign_in(@user)
+
+    visit admin_newsletter_path
+    assert_selector ".status-tab.active", text: "General"
+    assert_text "Select Email Service Provider"
+    assert_button "Save General Settings"
+
+    click_link "Native Email"
+    assert_selector ".status-tab.active", text: "Native Email"
+    assert_text "SMTP Configuration"
+    assert_button "Save Native Email Settings"
+
+    click_link "Listmonk"
+    assert_selector ".status-tab.active", text: "Listmonk"
+    assert_text "Listmonk Configuration"
+    assert_selector "select#list-select"
+    assert_selector "select#template-select"
+  end
+end


### PR DESCRIPTION
Add tabbed navigation to crosspost, git integration, migrate, and newsletter admin screens, preserving active tabs on redirects. Update activity table layout to wrap long descriptions and keep columns compact. Add controller and system tests to cover tab selection and redirects.