### PR TITLE
Fix sitemap XML namespace

### DIFF
--- a/app/views/sitemap/index.xml.builder
+++ b/app/views/sitemap/index.xml.builder
@@ -1,5 +1,5 @@
 xml.instruct! :xml, version: "1.0", encoding: "UTF-8"
-xml.urlset xmlns: "http://www.sitemaps.org/schemas/sitemap/1.1" do
+xml.urlset xmlns: "http://www.sitemaps.org/schemas/sitemap/0.9" do
   raw_site_url = site_settings[:url].to_s.strip
   site_url = raw_site_url.presence&.chomp("/")
   site_url = "https://#{site_url}" if site_url.present? && !site_url.match?(%r{^https?://})

--- a/test/controllers/sitemap_controller_test.rb
+++ b/test/controllers/sitemap_controller_test.rb
@@ -6,5 +6,6 @@ class SitemapControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "application/xml; charset=utf-8", response.content_type
     assert_includes response.body, "<urlset"
+    assert_includes response.body, "xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\""
   end
 end


### PR DESCRIPTION
Fixes the sitemap namespace to the standard 0.9 URI. Adds a test assertion so the correct namespace stays enforced.