### PR TITLE
Use simple_format for article descriptions

### DIFF
--- a/app/views/articles/_article_list.html.erb
+++ b/app/views/articles/_article_list.html.erb
@@ -29,7 +29,7 @@
           </h2>
           <% if article.description.present? %>
             <div class="post-description">
-              <%= article.description %>
+              <%= simple_format(article.description) %>
             </div>
           <% else %>
             <div class="post-content">
@@ -40,7 +40,7 @@
           <%= render 'articles/source_reference', article: article %>
           <% if article.description.present? %>
             <div class="post-description">
-              <%= article.description %>
+              <%= simple_format(article.description) %>
             </div>
           <% else %>
             <div class="post-content">

--- a/test/system/articles_test.rb
+++ b/test/system/articles_test.rb
@@ -33,9 +33,10 @@ class ArticlesTest < ApplicationSystemTestCase
   end
 
   test "home page shows description, falls back to full content when description blank" do
+    description_text = "First line\nSecond line"
     article_with_description = create_published_article(
       title: "Article With Description",
-      description: "Only the description should be shown",
+      description: description_text,
       content: "<p>CONTENT SHOULD NOT APPEAR</p>"
     )
     article_without_description = create_published_article(
@@ -47,8 +48,12 @@ class ArticlesTest < ApplicationSystemTestCase
     visit root_path
 
     assert_text article_with_description.title
-    assert_text "Only the description should be shown"
-    assert_no_text "CONTENT SHOULD NOT APPEAR"
+    within "article[data-article-id='#{article_with_description.id}']" do
+      assert_text "First line"
+      assert_text "Second line"
+      assert_selector ".post-description p br", count: 1
+      assert_no_text "CONTENT SHOULD NOT APPEAR"
+    end
 
     assert_text article_without_description.title
     assert_text "Fallback content should appear"


### PR DESCRIPTION
Switch article description rendering to simple_format so newlines render as paragraphs and line breaks. Update system test expectations for the generated <p> wrapper and <br> tag.