### PR TITLE
feat: 允许已退订用户重新订阅邮件列表

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -30,7 +30,7 @@ class SubscriptionsController < ApplicationController
 
     @subscriber = Subscriber.find_or_initialize_by(email: email)
 
-    if @subscriber.persisted? && @subscriber.confirmed?
+    if already_subscribed?(@subscriber)
       respond_to do |format|
         format.html do
           flash[:notice] = "您已经订阅了我们的邮件列表。"
@@ -39,6 +39,12 @@ class SubscriptionsController < ApplicationController
         format.json { render json: { success: true, message: "您已经订阅了我们的邮件列表。" } }
       end
       return
+    end
+
+    if @subscriber.persisted? && @subscriber.unsubscribed?
+      @subscriber.confirmed_at = nil
+      @subscriber.unsubscribed_at = nil
+      @subscriber.confirmation_token = SecureRandom.urlsafe_base64(32)
     end
 
     # 处理订阅的tags
@@ -134,4 +140,8 @@ class SubscriptionsController < ApplicationController
   end
 
   private
+
+  def already_subscribed?(subscriber)
+    subscriber.persisted? && subscriber.confirmed? && !subscriber.unsubscribed?
+  end
 end

--- a/test/controllers/subscriptions_controller_test.rb
+++ b/test/controllers/subscriptions_controller_test.rb
@@ -46,6 +46,28 @@ class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should allow resubscribe for unsubscribed subscriber" do
+    subscriber = subscribers(:unsubscribed_subscriber)
+    old_token = subscriber.confirmation_token
+
+    assert_no_difference "Subscriber.count" do
+      assert_enqueued_with(job: NewsletterConfirmationJob, args: [ subscriber.id ]) do
+        post subscriptions_path, params: {
+          subscription: {
+            email: subscriber.email
+          }
+        }.merge(captcha_params), as: :json
+      end
+    end
+
+    assert_response :success
+
+    subscriber.reload
+    assert_nil subscriber.confirmed_at
+    assert_nil subscriber.unsubscribed_at
+    assert_not_equal old_token, subscriber.confirmation_token
+  end
+
   test "should confirm subscription with valid token" do
     subscriber = subscribers(:unconfirmed_subscriber)
 


### PR DESCRIPTION
## 功能描述

允许已经退订的用户重新订阅邮件列表。

## 变更内容

- **新增重新订阅功能**: 已退订用户再次提交订阅时，重置其订阅状态
  - 清除 `confirmed_at`
  - 清除 `unsubscribed_at`  
  - 生成新的 `confirmation_token`
  - 发送确认邮件

- **代码重构**: 提取 `already_subscribed?` 私有方法，提高代码可读性

## 测试

- [x] 添加重新订阅功能的控制器测试
- [x] 验证不创建新订阅者记录
- [x] 验证发送确认邮件任务
- [x] 验证重置订阅状态

## 测试计划

- [ ] 已退订用户可重新提交订阅
- [ ] 重新订阅后收到确认邮件
- [ ] 点击确认链接后订阅成功
- [ ] 已确认用户仍提示"已订阅"

🤖 Generated with [Claude Code](https://claude.com/claude-code)