### PR TITLE
Refactor redirect handling and harden data workflows

### DIFF
--- a/app/jobs/fetch_social_comments_job.rb
+++ b/app/jobs/fetch_social_comments_job.rb
@@ -26,6 +26,7 @@ class FetchSocialCommentsJob < ApplicationJob
 
     articles = Article.published
                       .joins(:social_media_posts)
+                      .includes(:comments)
                       .where(social_media_posts: { platform: "mastodon" })
                       .where.not(social_media_posts: { url: nil })
                       .distinct
@@ -41,6 +42,7 @@ class FetchSocialCommentsJob < ApplicationJob
 
     articles = Article.published
                       .joins(:social_media_posts)
+                      .includes(:comments)
                       .where(social_media_posts: { platform: "bluesky" })
                       .where.not(social_media_posts: { url: nil })
                       .distinct

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -26,7 +26,6 @@ class Article < ApplicationRecord
   scope :published, -> { where(status: :publish) }
   scope :scheduled, -> { where(status: :schedule) }
   scope :by_status, ->(status) { where(status: status) }
-  # scope :paginate, ->(page, per_page) { offset((page - 1) * per_page).limit(per_page) }
   scope :publishable, -> { where(status: :schedule).where("scheduled_at <= ?", Time.current) }
 
   before_save :handle_time_zone, if: -> { schedule? && scheduled_at_changed? }

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -22,6 +22,7 @@ class Comment < ApplicationRecord
 
   # Validate that parent comment belongs to the same commentable
   validate :parent_belongs_to_same_commentable, if: :parent_id?
+  validate :parent_is_not_self, if: :parent_id?
 
   # Scopes
   enum :status, { pending: 0, approved: 1, rejected: 2 }, default: :pending
@@ -62,6 +63,10 @@ class Comment < ApplicationRecord
     if parent_record.commentable_type != commentable_type || parent_record.commentable_id != commentable_id
       errors.add(:parent_id, "must belong to the same #{commentable_type}")
     end
+  end
+
+  def parent_is_not_self
+    errors.add(:parent_id, "cannot reference itself") if parent_id == id
   end
 
   def enqueue_reply_notification

--- a/app/models/export.rb
+++ b/app/models/export.rb
@@ -110,7 +110,7 @@ class Export
         created_at updated_at
       ]
     ) do |csv|
-      Article.order(:id).find_each do |article|
+      Article.includes(:rich_text_content).order(:id).find_each do |article|
         # 处理文章内容和附件
         processed_content = process_article_content(article)
 
@@ -247,7 +247,7 @@ class Export
     Rails.event.notify("export.pages_started", component: "Export", level: "info")
 
     CSV.open(File.join(@export_dir, "pages.csv"), "w", write_headers: true, headers: %w[id title slug content status redirect_url page_order content_type html_content comment created_at updated_at]) do |csv|
-      Page.order(:id).find_each do |page|
+      Page.includes(:rich_text_content).order(:id).find_each do |page|
         # 处理页面内容（如果有富文本内容的话）
         content = page.content.present? ? process_page_content(page) : ""
 
@@ -294,7 +294,7 @@ class Export
         github_backup_branch created_at updated_at
       ]
     ) do |csv|
-      Setting.order(:id).find_each do |setting|
+      Setting.includes(:rich_text_footer).order(:id).find_each do |setting|
         # 处理footer内容（如果有富文本内容的话）
         footer_content = setting.footer.present? ? process_setting_footer(setting) : ""
 
@@ -344,7 +344,7 @@ class Export
     Rails.event.notify("export.social_media_posts_started", component: "Export", level: "info")
 
     CSV.open(File.join(@export_dir, "social_media_posts.csv"), "w", write_headers: true, headers: %w[id article_id article_slug platform url created_at updated_at]) do |csv|
-      SocialMediaPost.order(:id).find_each do |post|
+      SocialMediaPost.includes(:article).order(:id).find_each do |post|
         csv << [
           post.id,
           post.article_id,
@@ -382,7 +382,7 @@ class Export
     Rails.event.notify("export.comments_started", component: "Export", level: "info")
 
     CSV.open(File.join(@export_dir, "comments.csv"), "w", write_headers: true, headers: %w[id article_id article_slug parent_id author_name author_url author_username author_avatar_url content platform external_id status published_at url created_at updated_at]) do |csv|
-      Comment.order(:id).find_each do |comment|
+      Comment.includes(:article).order(:id).find_each do |comment|
         csv << [
           comment.id,
           comment.article_id,
@@ -411,7 +411,7 @@ class Export
     Rails.event.notify("export.static_files_started", component: "Export", level: "info")
 
     CSV.open(File.join(@export_dir, "static_files.csv"), "w", write_headers: true, headers: %w[id filename blob_filename description created_at updated_at]) do |csv|
-      StaticFile.order(:id).find_each do |static_file|
+      StaticFile.includes(file_attachment: :blob).order(:id).find_each do |static_file|
         unless static_file.file.attached?
           Rails.event.notify("export.static_file_skipped", component: "Export", static_file_id: static_file.id, reason: "no_attached_file", level: "warn")
           next
@@ -470,7 +470,7 @@ class Export
     Rails.event.notify("export.newsletter_settings_started", component: "Export", level: "info")
 
     CSV.open(File.join(@export_dir, "newsletter_settings.csv"), "w", write_headers: true, headers: %w[id provider enabled smtp_address smtp_port smtp_user_name smtp_password smtp_domain smtp_authentication smtp_enable_starttls from_email footer created_at updated_at]) do |csv|
-      NewsletterSetting.order(:id).find_each do |setting|
+      NewsletterSetting.includes(:rich_text_footer).order(:id).find_each do |setting|
         # 处理footer内容（如果有富文本内容的话）
         footer_content = setting.footer.present? ? process_newsletter_setting_footer(setting) : ""
 
@@ -528,7 +528,7 @@ class Export
     Rails.event.notify("export.article_tags_started", component: "Export", level: "info")
 
     CSV.open(File.join(@export_dir, "article_tags.csv"), "w", write_headers: true, headers: %w[id article_id article_slug tag_id tag_name tag_slug created_at updated_at]) do |csv|
-      ArticleTag.order(:id).find_each do |article_tag|
+      ArticleTag.includes(:article, :tag).order(:id).find_each do |article_tag|
         csv << [
           article_tag.id,
           article_tag.article_id,
@@ -549,7 +549,7 @@ class Export
     Rails.event.notify("export.subscriber_tags_started", component: "Export", level: "info")
 
     CSV.open(File.join(@export_dir, "subscriber_tags.csv"), "w", write_headers: true, headers: %w[id subscriber_id subscriber_email tag_id tag_name tag_slug created_at updated_at]) do |csv|
-      SubscriberTag.order(:id).find_each do |subscriber_tag|
+      SubscriberTag.includes(:subscriber, :tag).order(:id).find_each do |subscriber_tag|
         csv << [
           subscriber_tag.id,
           subscriber_tag.subscriber_id,

--- a/app/models/import_zip.rb
+++ b/app/models/import_zip.rb
@@ -68,10 +68,6 @@ class ImportZip
     FileUtils.rm_rf(@import_dir) if @import_dir && File.directory?(@import_dir)
   end
 
-  def error_message
-    @error_message
-  end
-
   private
 
   def extract_zip_file

--- a/app/models/listmonk.rb
+++ b/app/models/listmonk.rb
@@ -22,12 +22,6 @@ class Listmonk < ApplicationRecord
       end
 
       if response.is_a?(Net::HTTPSuccess)
-        # ActivityLog.create!(
-        #   action: "newsletter",
-        #   target: "newsletter",
-        #   level: :info,
-        #   description: "Fetch Lists successfully!"
-        # )
         JSON.parse(response.body)["data"]["results"]
       else
         raise "Fetch Lists failed! #{response.code} - #{response.body}"
@@ -55,12 +49,6 @@ class Listmonk < ApplicationRecord
       end
 
       if response.is_a?(Net::HTTPSuccess)
-        # ActivityLog.create!(
-        #   action: "newsletter",
-        #   target: "newsletter",
-        #   level: :info,
-        #   description: "Fetch Templates successfully!"
-        # )
         JSON.parse(response.body)["data"]
       else
         raise "Fetch Template failed! #{response.code} - #{response.body}"

--- a/app/models/redirect.rb
+++ b/app/models/redirect.rb
@@ -1,4 +1,6 @@
 class Redirect < ApplicationRecord
+  REGEX_TIMEOUT = 1 # seconds
+
   validates :regex, presence: true
   validates :replacement, presence: true
   validate :validate_regex_pattern
@@ -13,18 +15,20 @@ class Redirect < ApplicationRecord
 
   def match?(path)
     return false unless enabled?
-    compiled_regex.match?(path)
-  rescue RegexpError
+    Timeout.timeout(REGEX_TIMEOUT) { compiled_regex.match?(path) }
+  rescue RegexpError, Timeout::Error
     false
   end
 
   def apply_to(path)
     return nil unless match?(path)
-    result = path.sub(compiled_regex, replacement)
-    # If the regex matched the entire path (common case), return the replacement directly
-    # Otherwise return the substituted result
-    result
-  rescue RegexpError
+    Timeout.timeout(REGEX_TIMEOUT) do
+      result = path.sub(compiled_regex, replacement)
+      # If the regex matched the entire path (common case), return the replacement directly
+      # Otherwise return the substituted result
+      result
+    end
+  rescue RegexpError, Timeout::Error
     nil
   end
 

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,6 +1,7 @@
 class Setting < ApplicationRecord
   has_rich_text :footer
   before_save :parse_social_links_json
+  after_commit :clear_settings_cache
   validates :url, presence: true, if: :setup_completed?
 
   # Virtual attribute for JSON textarea input
@@ -24,5 +25,9 @@ class Setting < ApplicationRecord
         throw :abort
       end
     end
+  end
+
+  def clear_settings_cache
+    CacheableSettings.refresh_site_info
   end
 end

--- a/app/services/bluesky_service.rb
+++ b/app/services/bluesky_service.rb
@@ -1,6 +1,7 @@
 # COPY from: https://t27duck.com/posts/17-a-bluesky-at-proto-api-example-in-ruby
 class BlueskyService
   include ContentBuilder
+  include HttpRedirectHandler
 
   TOKEN_CACHE_KEY = :bluesky_token_data
 
@@ -230,19 +231,6 @@ class BlueskyService
 
   private
 
-
-
-  def retrieve_server_token
-    token_data = Rails.cache.read(TOKEN_CACHE_KEY)
-    if token_data.present?
-      process_tokens(token_data)
-      @token
-    else
-      verify_tokens
-      @token
-    end
-  end
-
   def link_facets(message)
     [].tap do |facets|
       matches = []
@@ -267,20 +255,6 @@ class BlueskyService
         facets << {
           "index" => { "byteStart" => start, "byteEnd" => stop },
           "features" => [ { "uri" => url, "$type" => "app.bsky.richtext.facet#link" } ]
-        }
-      end
-    end
-  end
-
-  def tag_facets(message)
-    [].tap do |facets|
-      matches = []
-      message.scan(/(^|[^\w])(#[\w\-]+)/) { matches << Regexp.last_match }
-      matches.each do |match|
-        start, stop = match.byteoffset(2)
-        facets << {
-          "index" => { "byteStart" => start, "byteEnd" => stop },
-          "features" => [ { "tag" => match[2].delete_prefix("#"), "$type" => "app.bsky.richtext.facet#tag" } ]
         }
       end
     end
@@ -521,26 +495,10 @@ class BlueskyService
       # 确保token有效
       verify_tokens
 
-      # 将相对 URL 转换为绝对 URL
-      if image_url.start_with?("/")
-        site_url = Setting.first&.url.presence || "http://localhost:3000"
-        image_url = "#{site_url}#{image_url}"
-      end
+      result = download_remote_image_with_redirect(image_url)
+      return nil unless result
 
-      # 下载远程图片，支持重定向（ActiveStorage redirect URLs)
-      uri = URI.parse(image_url)
-      image_response = fetch_with_redirect(uri)
-
-      unless image_response.is_a?(Net::HTTPSuccess)
-        Rails.event.notify "bluesky_service.remote_image_download_failed",
-          level: "error",
-          component: "BlueskyService",
-          response_code: image_response.code
-        return nil
-      end
-
-      image_data = image_response.body
-      content_type = image_response["content-type"] || "image/jpeg"
+      image_data, content_type = result
 
       # 如果图片太大，进行压缩
       image_data, content_type = resize_image_if_needed(image_data, content_type)
@@ -578,6 +536,13 @@ class BlueskyService
         backtrace: e.backtrace.join("\n")
       nil
     end
+  end
+
+  def log_redirect(redirect_uri)
+    Rails.event.notify "bluesky_service.following_redirect",
+      level: "info",
+      component: "BlueskyService",
+      redirect_uri: redirect_uri.to_s
   end
 
   # 如果图片太大，使用 ruby-vips 压缩

--- a/app/services/concerns/http_redirect_handler.rb
+++ b/app/services/concerns/http_redirect_handler.rb
@@ -1,0 +1,64 @@
+module HttpRedirectHandler
+  extend ActiveSupport::Concern
+
+  # Shared HTTP configuration constants
+  MAX_REDIRECTS = 5
+  DEFAULT_OPEN_TIMEOUT = 10
+  DEFAULT_READ_TIMEOUT = 10
+  DEFAULT_WRITE_TIMEOUT = 10
+
+  # Follow HTTP redirects to fetch content
+  # @param uri [URI] The URI to fetch
+  # @param limit [Integer] Maximum number of redirects to follow
+  # @return [Net::HTTPResponse] The final response
+  def fetch_with_redirect(uri, limit = MAX_REDIRECTS)
+    raise "Too many HTTP redirects" if limit == 0
+
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = (uri.scheme == "https")
+    http.open_timeout = DEFAULT_OPEN_TIMEOUT
+    http.read_timeout = DEFAULT_READ_TIMEOUT
+
+    path = uri.path.presence || "/"
+    path += "?#{uri.query}" if uri.query
+    request = Net::HTTP::Get.new(path)
+    response = http.request(request)
+
+    case response
+    when Net::HTTPSuccess
+      response
+    when Net::HTTPRedirection
+      redirect_uri = URI.parse(response["location"])
+      if redirect_uri.relative?
+        redirect_uri = URI.join("#{uri.scheme}://#{uri.host}:#{uri.port}", response["location"])
+      end
+      log_redirect(redirect_uri) if respond_to?(:log_redirect, true)
+      fetch_with_redirect(redirect_uri, limit - 1)
+    else
+      response
+    end
+  end
+
+  # Download a remote image with redirect support
+  # @param image_url [String] The URL of the image
+  # @return [Array<String, String>, nil] [image_data, content_type] or nil on failure
+  def download_remote_image_with_redirect(image_url)
+    return nil unless image_url.present?
+
+    # Convert relative URL to absolute
+    if image_url.start_with?("/")
+      site_url = Setting.first&.url.presence || "http://localhost:3000"
+      image_url = "#{site_url}#{image_url}"
+    end
+
+    uri = URI.parse(image_url)
+    response = fetch_with_redirect(uri)
+
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    [response.body, response["content-type"] || "image/jpeg"]
+  rescue StandardError => e
+    log_download_error(e, image_url) if respond_to?(:log_download_error, true)
+    nil
+  end
+end

--- a/app/services/concerns/http_redirect_handler.rb
+++ b/app/services/concerns/http_redirect_handler.rb
@@ -56,7 +56,7 @@ module HttpRedirectHandler
 
     return nil unless response.is_a?(Net::HTTPSuccess)
 
-    [response.body, response["content-type"] || "image/jpeg"]
+    [ response.body, response["content-type"] || "image/jpeg" ]
   rescue StandardError => e
     log_download_error(e, image_url) if respond_to?(:log_download_error, true)
     nil

--- a/app/services/mastodon_service.rb
+++ b/app/services/mastodon_service.rb
@@ -3,6 +3,7 @@ require "uri"
 
 class MastodonService
   include ContentBuilder
+  include HttpRedirectHandler
 
   def initialize
     @settings = Crosspost.mastodon
@@ -201,13 +202,6 @@ class MastodonService
   end
 
   private
-
-  # def create_client
-  #   Mastodon::REST::Client.new(
-  #     base_url: @settings[:server_url],
-  #     bearer_token: @settings.access_token
-  #   )
-  # end
 
   def upload_image(attachable)
     Rails.event.notify "mastodon_service.upload_image_started",
@@ -447,69 +441,23 @@ class MastodonService
 
   # Download remote image with redirect support
   def download_remote_image(image_url)
-    return nil unless image_url.present?
-
-    begin
-      # 将相对 URL 转换为绝对 URL
-      if image_url.start_with?("/")
-        site_url = Setting.first&.url.presence || "http://localhost:3000"
-        image_url = "#{site_url}#{image_url}"
-      end
-
-      # 下载远程图片，支持重定向（ActiveStorage redirect URLs)
-      uri = URI.parse(image_url)
-      image_response = fetch_with_redirect(uri)
-
-      unless image_response.is_a?(Net::HTTPSuccess)
-        Rails.event.notify "mastodon_service.remote_image_download_failed",
-          level: "error",
-          component: "MastodonService",
-          response_code: image_response.code
-        return nil
-      end
-
-      image_data = image_response.body
-      content_type = image_response["content-type"] || "image/jpeg"
-
-      [ image_data, content_type ]
-    rescue => e
-      Rails.event.notify "mastodon_service.remote_image_download_error",
-        level: "error",
-        component: "MastodonService",
-        error_message: e.message,
-        backtrace: e.backtrace.join("\n")
-      nil
-    end
+    result = download_remote_image_with_redirect(image_url)
+    return nil unless result
+    result
   end
 
-  # 跟随HTTP重定向获取图片
-  def fetch_with_redirect(uri, limit = 5)
-    raise "Too many HTTP redirects" if limit == 0
+  def log_redirect(redirect_uri)
+    Rails.event.notify "mastodon_service.following_redirect",
+      level: "info",
+      component: "MastodonService",
+      redirect_uri: redirect_uri.to_s
+  end
 
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = (uri.scheme == "https")
-    http.open_timeout = 10
-    http.read_timeout = 10
-
-    request = Net::HTTP::Get.new(uri.path + (uri.query ? "?#{uri.query}" : ""))
-    response = http.request(request)
-
-    case response
-    when Net::HTTPSuccess
-      response
-    when Net::HTTPRedirection
-      redirect_uri = URI.parse(response["location"])
-      # 如果是相对URL，补全域名
-      if redirect_uri.relative?
-        redirect_uri = URI.join("#{uri.scheme}://#{uri.host}:#{uri.port}", response["location"])
-      end
-      Rails.event.notify "mastodon_service.following_redirect",
-        level: "info",
-        component: "MastodonService",
-        redirect_uri: redirect_uri.to_s
-      fetch_with_redirect(redirect_uri, limit - 1)
-    else
-      response
-    end
+  def log_download_error(error, url)
+    Rails.event.notify "mastodon_service.remote_image_download_error",
+      level: "error",
+      component: "MastodonService",
+      error_message: error.message,
+      url: url
   end
 end

--- a/app/services/twitter_service.rb
+++ b/app/services/twitter_service.rb
@@ -6,6 +6,7 @@ require "json"
 
 class TwitterService
   include ContentBuilder
+  include HttpRedirectHandler
 
   def initialize
     @settings = Crosspost.twitter
@@ -403,25 +404,25 @@ class TwitterService
   def upload_image(client, attachable)
     return nil unless attachable
 
+    temp_file = nil
     begin
       # 创建临时文件来存储图片数据
       temp_file = create_temp_image_file(attachable)
       return nil unless temp_file
 
       # 使用 Twitter API v1.1 上传媒体
-      media_id = upload_media_to_twitter(client, temp_file.path)
-
-      # 清理临时文件
-      temp_file.close
-      temp_file.unlink
-
-      media_id
+      upload_media_to_twitter(client, temp_file.path)
     rescue => e
       Rails.event.notify "twitter_service.upload_image_error",
         level: "error",
         component: "TwitterService",
         error_message: e.message
       nil
+    ensure
+      if temp_file
+        temp_file.close rescue nil
+        temp_file.unlink rescue nil
+      end
     end
   end
 
@@ -434,9 +435,6 @@ class TwitterService
 
     # 使用简单的媒体上传（非分块上传）
     begin
-      # 读取文件数据
-      file_data = File.binread(file_path)
-
       # 创建 multipart/form-data 请求
       boundary = SecureRandom.hex
       upload_body = construct_upload_body(file_path, boundary)
@@ -513,61 +511,25 @@ class TwitterService
     image_url = remote_image.url
     return nil unless image_url.present?
 
-    # 处理相对URL
-    if image_url.start_with?("/")
-      site_url = Setting.first&.url.presence || "http://localhost:3000"
-      image_url = "#{site_url}#{image_url}"
-    end
+    result = download_remote_image_with_redirect(image_url)
+    return nil unless result
 
-    # 下载图片，支持重定向
-    uri = URI.parse(image_url)
-    response = fetch_with_redirect(uri)
+    result.first # Return just the image data
+  end
 
-    if response.is_a?(Net::HTTPSuccess)
-      response.body
-    else
-      Rails.event.notify "twitter_service.download_remote_image_failed",
-        level: "error",
-        component: "TwitterService",
-        response_code: response.code
-      nil
-    end
-  rescue => e
+  def log_redirect(redirect_uri)
+    Rails.event.notify "twitter_service.following_redirect",
+      level: "info",
+      component: "TwitterService",
+      redirect_uri: redirect_uri.to_s
+  end
+
+  def log_download_error(error, url)
     Rails.event.notify "twitter_service.download_remote_image_error",
       level: "error",
       component: "TwitterService",
-      error_message: e.message
-    nil
-  end
-
-  def fetch_with_redirect(uri, limit = 5)
-    raise "Too many HTTP redirects" if limit == 0
-
-    http = Net::HTTP.new(uri.host, uri.port)
-    http.use_ssl = (uri.scheme == "https")
-    http.open_timeout = 10
-    http.read_timeout = 10
-
-    request = Net::HTTP::Get.new(uri.path + (uri.query ? "?#{uri.query}" : ""))
-    response = http.request(request)
-
-    case response
-    when Net::HTTPSuccess
-      response
-    when Net::HTTPRedirection
-      redirect_uri = URI.parse(response["location"])
-      # 处理相对URL重定向
-      if redirect_uri.relative?
-        redirect_uri = URI.join("#{uri.scheme}://#{uri.host}:#{uri.port}", response["location"])
-      end
-      Rails.event.notify "twitter_service.following_redirect",
-        level: "info",
-        component: "TwitterService",
-        redirect_uri: redirect_uri.to_s
-      fetch_with_redirect(redirect_uri, limit - 1)
-    else
-      response
-    end
+      error_message: error.message,
+      url: url
   end
 
   # Build OAuth 1.0a authorization header for Twitter API
@@ -617,15 +579,6 @@ class TwitterService
       "Content-Type: image/jpeg\r\n\r\n" \
       "#{file_data}\r\n" \
       "--#{boundary}--\r\n"
-  end
-
-  def check_media_status(client, media_id)
-    # 简化媒体状态检查 - 由于API限制，我们假设上传的媒体是可用的
-    # 实际的状态检查可能需要更高级的API访问权限
-    return true unless media_id
-
-    Rails.event.notify("twitter_service.media_status_check_skipped", level: "info", component: "TwitterService", media_id: media_id, reason: "API limitations")
-    true
   end
 
   def quote_tweet_id_for_article(article)

--- a/test/models/setting_test.rb
+++ b/test/models/setting_test.rb
@@ -19,4 +19,12 @@ class SettingTest < ActiveSupport::TestCase
     setting.update!(setup_completed: false)
     assert Setting.setup_incomplete?
   end
+
+  test "registers cache invalidation on commit callback" do
+    save_after_filters = Setting._save_callbacks.select { |callback| callback.kind == :after }.map(&:filter)
+    commit_after_filters = Setting._commit_callbacks.select { |callback| callback.kind == :after }.map(&:filter)
+
+    refute_includes save_after_filters, :clear_settings_cache
+    assert_includes commit_after_filters, :clear_settings_cache
+  end
 end


### PR DESCRIPTION
## Summary
- extract shared redirect-following image download logic into HttpRedirectHandler and reuse in Twitter/Mastodon/Bluesky services
- harden models with safer redirect regex matching timeout, self-parent comment validation, and settings cache refresh after commit
- reduce export/comment fetching N+1 risks and clean up dead/commented code

## Testing
- mise exec -- bin/rails test test/models/setting_test.rb